### PR TITLE
feat: interface for search request

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -101,6 +101,12 @@
             <version>1.7.36</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>nl.jqno.equalsverifier</groupId>
+            <artifactId>equalsverifier</artifactId>
+            <version>3.10</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <extensions>

--- a/client/src/main/java/com/tigrisdata/db/client/Constants.java
+++ b/client/src/main/java/com/tigrisdata/db/client/Constants.java
@@ -49,6 +49,7 @@ final class Constants {
   public static final String UPDATE_FAILED = "Failed to update";
   public static final String DELETE_FAILED = "Failed to delete";
   public static final String READ_FAILED = "Failed to read";
+  public static final String SEARCH_FAILED = "Failed to search";
   public static final String STREAM_FAILED = "Failed to stream events";
   public static final String STREAM_CONVERT_FAILED = "Failed to convert event data";
   public static final String DESCRIBE_COLLECTION_FAILED = "Failed to describe collection";

--- a/client/src/main/java/com/tigrisdata/db/client/JSONSerializable.java
+++ b/client/src/main/java/com/tigrisdata/db/client/JSONSerializable.java
@@ -11,7 +11,17 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.tigrisdata.db.client;
 
-/** Represents the filter */
-public interface TigrisFilter extends JSONSerializable {}
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public interface JSONSerializable {
+  /**
+   * Converts Object to JSON string representation
+   *
+   * @param objectMapper custom
+   * @return string representation of the object
+   */
+  String toJSON(ObjectMapper objectMapper);
+}

--- a/client/src/main/java/com/tigrisdata/db/client/ReadFields.java
+++ b/client/src/main/java/com/tigrisdata/db/client/ReadFields.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.tigrisdata.db.client;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -11,7 +25,7 @@ import java.util.Map;
  * Represents Fields to read from server. This is useful in cases when you want to read fields
  * selectively instead of reading entire document.
  */
-public final class ReadFields {
+public final class ReadFields implements JSONSerializable {
   private final Map<String, Object> internalMap;
   private static final ReadFields EMPTY = new ReadFields(Collections.emptyMap());
 
@@ -32,7 +46,8 @@ public final class ReadFields {
     return EMPTY;
   }
 
-  String toJSON(ObjectMapper objectMapper) {
+  @Override
+  public String toJSON(ObjectMapper objectMapper) {
     try {
       return objectMapper.writeValueAsString(internalMap);
     } catch (JsonProcessingException ex) {

--- a/client/src/main/java/com/tigrisdata/db/client/StandardTigrisCollection.java
+++ b/client/src/main/java/com/tigrisdata/db/client/StandardTigrisCollection.java
@@ -13,17 +13,20 @@
  */
 package com.tigrisdata.db.client;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.tigrisdata.db.api.v1.grpc.Api;
-import com.tigrisdata.db.api.v1.grpc.TigrisGrpc;
 import static com.tigrisdata.db.client.Constants.DESCRIBE_COLLECTION_FAILED;
 import static com.tigrisdata.db.client.Constants.READ_FAILED;
 import static com.tigrisdata.db.client.TypeConverter.toCollectionDescription;
 import static com.tigrisdata.db.client.TypeConverter.toCollectionOptions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tigrisdata.db.api.v1.grpc.Api;
+import com.tigrisdata.db.api.v1.grpc.TigrisGrpc;
 import com.tigrisdata.db.client.error.TigrisException;
+import com.tigrisdata.db.client.search.SearchRequest;
+import com.tigrisdata.db.client.search.SearchRequestOptions;
+import com.tigrisdata.db.client.search.SearchResult;
 import com.tigrisdata.db.type.TigrisCollectionType;
 import io.grpc.StatusRuntimeException;
-
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -105,6 +108,17 @@ class StandardTigrisCollection<T extends TigrisCollectionType> extends AbstractT
           statusRuntimeException);
     }
     return Optional.empty();
+  }
+
+  @Override
+  public Iterator<SearchResult<T>> search(SearchRequest request, SearchRequestOptions options)
+      throws TigrisException {
+    return this.searchInternal(request, options);
+  }
+
+  @Override
+  public Iterator<SearchResult<T>> search(SearchRequest request) throws TigrisException {
+    return this.search(request, SearchRequestOptions.getDefault());
   }
 
   @Override

--- a/client/src/main/java/com/tigrisdata/db/client/TigrisCollection.java
+++ b/client/src/main/java/com/tigrisdata/db/client/TigrisCollection.java
@@ -14,8 +14,10 @@
 package com.tigrisdata.db.client;
 
 import com.tigrisdata.db.client.error.TigrisException;
+import com.tigrisdata.db.client.search.SearchRequest;
+import com.tigrisdata.db.client.search.SearchRequestOptions;
+import com.tigrisdata.db.client.search.SearchResult;
 import com.tigrisdata.db.type.TigrisCollectionType;
-
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -75,6 +77,27 @@ public interface TigrisCollection<T extends TigrisCollectionType>
    * @throws TigrisException in case of an error
    */
   Optional<T> readOne(TigrisFilter filter) throws TigrisException;
+
+  /**
+   * Search for documents in a collection. Easily perform sophisticated queries and refine results
+   * using filters with advanced features like faceting and ordering.
+   *
+   * <p>Note: Searching is expensive. If using as a primary key based lookup, use {@code read()}
+   * instead
+   *
+   * @param request search request to execute
+   * @param options search pagination options
+   * @return stream of search results
+   * @throws TigrisException in case of error
+   */
+  Iterator<SearchResult<T>> search(SearchRequest request, SearchRequestOptions options)
+      throws TigrisException;
+
+  /**
+   * @param request search request to execute
+   * @return stream of search results
+   */
+  Iterator<SearchResult<T>> search(SearchRequest request) throws TigrisException;
 
   /**
    * Inserts the documents into collection.

--- a/client/src/main/java/com/tigrisdata/db/client/search/FacetCount.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/FacetCount.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.tigrisdata.db.api.v1.grpc.Api;
+import java.util.Objects;
+
+/** Representation of {@link Api.FacetCount}, aggregate count of a value in field */
+public final class FacetCount {
+
+  private final String value;
+  private final long count;
+
+  private FacetCount(String value, long count) {
+    this.value = value;
+    this.count = count;
+  }
+
+  /** Field value */
+  public String getValue() {
+    return value;
+  }
+
+  /** Number of field values in the dataset */
+  public long getCount() {
+    return count;
+  }
+
+  /**
+   * Conversion utility to create {@link FacetCount}
+   *
+   * @param resp {@link Api.FacetCount}
+   */
+  static FacetCount from(Api.FacetCount resp) {
+    Objects.requireNonNull(resp);
+    return new FacetCount(resp.getValue(), resp.getCount());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    FacetCount that = (FacetCount) o;
+
+    if (count != that.count) {
+      return false;
+    }
+    return Objects.equals(value, that.value);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = value != null ? value.hashCode() : 0;
+    result = 31 * result + (int) (count ^ (count >>> 32));
+    return result;
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/search/FacetCountDistribution.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/FacetCountDistribution.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.tigrisdata.db.api.v1.grpc.Api;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/** Representation of {@link Api.SearchFacet} */
+public final class FacetCountDistribution {
+
+  private final List<FacetCount> counts;
+  private final FacetStats stats;
+
+  private FacetCountDistribution(List<FacetCount> counts, FacetStats stats) {
+    this.counts = Collections.unmodifiableList(counts);
+    this.stats = stats;
+  }
+
+  /**
+   * List of field values and their aggregated counts
+   *
+   * @return immutable {@link List<FacetCount>}
+   */
+  public List<FacetCount> getCounts() {
+    return counts;
+  }
+
+  /** Statistics for this particular field */
+  public FacetStats getStats() {
+    return stats;
+  }
+
+  /**
+   * Conversion utility to create {@link FacetCountDistribution} from server response
+   *
+   * @param resp {@link Api.SearchFacet}
+   */
+  static FacetCountDistribution from(Api.SearchFacet resp) {
+    Objects.requireNonNull(resp);
+
+    List<FacetCount> counts =
+        Optional.of(resp.getCountsList())
+            .map(c -> c.stream().map(FacetCount::from).collect(Collectors.toList()))
+            .orElse(Collections.emptyList());
+
+    FacetStats stats = Optional.of(resp.getStats()).map(FacetStats::from).orElse(null);
+
+    return new FacetCountDistribution(counts, stats);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    FacetCountDistribution that = (FacetCountDistribution) o;
+
+    if (!Objects.equals(counts, that.counts)) {
+      return false;
+    }
+    return Objects.equals(stats, that.stats);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = counts != null ? counts.hashCode() : 0;
+    result = 31 * result + (stats != null ? stats.hashCode() : 0);
+    return result;
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/search/FacetFieldsQuery.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/FacetFieldsQuery.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Represents a facet query input for /search */
+public final class FacetFieldsQuery implements FacetQuery {
+  private static final FacetFieldsQuery EMPTY = newBuilder().build();
+
+  private final Map<String, FacetQueryOptions> internalMap;
+
+  private FacetFieldsQuery(Builder builder) {
+    this.internalMap = Collections.unmodifiableMap(builder.fieldMap);
+  }
+
+  /**
+   * This represents empty facet query, server will not return any facet results
+   *
+   * @return an empty {@link FacetFieldsQuery}
+   */
+  public static FacetFieldsQuery empty() {
+    return EMPTY;
+  }
+
+  /**
+   * Returns a mapping of field names and facet query options
+   *
+   * @return non-null immutable {@link Map}
+   */
+  public Map<String, FacetQueryOptions> getFacetFields() {
+    return this.internalMap;
+  }
+
+  /**
+   * Returns True if there is no entry in facet query, False otherwise
+   *
+   * @return boolean
+   */
+  public boolean isEmpty() {
+    return internalMap.isEmpty();
+  }
+
+  @Override
+  public String toJSON(ObjectMapper objectMapper) {
+    try {
+      return objectMapper.writeValueAsString(internalMap);
+    } catch (JsonProcessingException ex) {
+      throw new IllegalArgumentException("Failed to serialize FacetFields to JSON", ex);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    FacetFieldsQuery fields = (FacetFieldsQuery) o;
+
+    return Objects.equals(internalMap, fields.internalMap);
+  }
+
+  @Override
+  public int hashCode() {
+    return internalMap != null ? internalMap.hashCode() : 0;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+
+    private Map<String, FacetQueryOptions> fieldMap;
+
+    private Builder() {}
+
+    /**
+     * Field to include facet results in /search response Uses default {@link FacetQueryOptions}
+     * options
+     *
+     * @param field - schema field name as string
+     */
+    public Builder withField(String field) {
+      if (fieldMap == null) {
+        fieldMap = new HashMap<>();
+      }
+      fieldMap.put(field, FacetQueryOptions.getDefaultInstance());
+      return this;
+    }
+
+    /**
+     * Fields to include facet results in /search response
+     *
+     * @param field schema field name as string
+     * @param options Options
+     */
+    public Builder withFieldOptions(String field, FacetQueryOptions options) {
+      if (fieldMap == null) {
+        fieldMap = new HashMap<>();
+      }
+      fieldMap.put(field, options);
+      return this;
+    }
+
+    /** @param fieldOptions Map of schema field names and query options */
+    public Builder addAll(Map<String, FacetQueryOptions> fieldOptions) {
+      if (fieldMap == null) {
+        fieldMap = new HashMap<>();
+      }
+      fieldMap.putAll(fieldOptions);
+      return this;
+    }
+
+    /** Builds a {@link FacetFieldsQuery} */
+    public FacetFieldsQuery build() {
+      if (fieldMap == null) {
+        fieldMap = Collections.emptyMap();
+      }
+      return new FacetFieldsQuery(this);
+    }
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/search/FacetQuery.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/FacetQuery.java
@@ -11,7 +11,9 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tigrisdata.db.client;
 
-/** Represents the filter */
-public interface TigrisFilter extends JSONSerializable {}
+package com.tigrisdata.db.client.search;
+
+import com.tigrisdata.db.client.JSONSerializable;
+
+public interface FacetQuery extends JSONSerializable {}

--- a/client/src/main/java/com/tigrisdata/db/client/search/FacetQueryOptions.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/FacetQueryOptions.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tigrisdata.db.client.JSONSerializable;
+import java.util.HashMap;
+import java.util.Map;
+
+enum FacetFieldType {
+  value("value");
+  private final String strVal;
+
+  FacetFieldType(String v) {
+    this.strVal = v;
+  }
+
+  @Override
+  public String toString() {
+    return this.strVal;
+  }
+}
+
+/** Represents options related to Facet query for /search */
+public final class FacetQueryOptions implements JSONSerializable {
+
+  private static final long DEFAULT_LIMIT = 10;
+  private static final FacetFieldType DEFAULT_TYPE = FacetFieldType.value;
+  private static final FacetQueryOptions DEFAULT_INSTANCE = newBuilder().build();
+
+  private final FacetFieldType type;
+  private final long limit;
+
+  private FacetQueryOptions(Builder builder) {
+    this.type = builder.type;
+    this.limit = builder.limit;
+  }
+
+  /**
+   * Default options for a facet query type: value limit: 10
+   *
+   * @return {@link FacetQueryOptions}
+   */
+  public static FacetQueryOptions getDefaultInstance() {
+    return DEFAULT_INSTANCE;
+  }
+
+  /** Type of schema field */
+  public FacetFieldType getType() {
+    return type;
+  }
+
+  /** Maximum number facet results to include in /search response */
+  public long getLimit() {
+    return limit;
+  }
+
+  @Override
+  public String toJSON(ObjectMapper objectMapper) {
+    Map<String, String> map =
+        new HashMap<String, String>() {
+          {
+            put("type", type.toString());
+            put("limit", String.valueOf(limit));
+          }
+        };
+
+    try {
+      return objectMapper.writeValueAsString(map);
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException("Failed to serialize FacetFieldOption to JSON", e);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    FacetQueryOptions that = (FacetQueryOptions) o;
+
+    if (limit != that.limit) {
+      return false;
+    }
+    return type == that.type;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = type != null ? type.hashCode() : 0;
+    result = 31 * result + (int) (limit ^ (limit >>> 32));
+    return result;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+
+    private FacetFieldType type;
+
+    private long limit;
+
+    private Builder() {
+      this.type = DEFAULT_TYPE;
+      this.limit = DEFAULT_LIMIT;
+    }
+
+    /** Type of schema field */
+    public Builder withType(FacetFieldType type) {
+      this.type = type;
+      return this;
+    }
+
+    /** Maximum number facet results to include in /search response */
+    public Builder withLimit(long limit) {
+      this.limit = limit;
+      return this;
+    }
+
+    /** Builds {@link FacetQueryOptions} */
+    public FacetQueryOptions build() {
+      if (this.type == null) {
+        this.type = DEFAULT_TYPE;
+      }
+      return new FacetQueryOptions(this);
+    }
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/search/FacetStats.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/FacetStats.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.tigrisdata.db.api.v1.grpc.Api;
+import java.util.Objects;
+
+/** Representation of {@link Api.FacetStats}, summary of Facet results */
+public final class FacetStats {
+
+  private final double avg;
+  private final long count;
+  private final long max;
+  private final long min;
+  private final long sum;
+
+  private FacetStats(double avg, long count, long max, long min, long sum) {
+    this.avg = avg;
+    this.count = count;
+    this.max = max;
+    this.min = min;
+    this.sum = sum;
+  }
+
+  /** Number of values in a faceted field */
+  public long getCount() {
+    return count;
+  }
+
+  /** Only for numeric fields. Average of values for the field */
+  public double getAvg() {
+    return avg;
+  }
+
+  /** Only for numeric fields. Maximum numeric value for a field */
+  public long getMax() {
+    return max;
+  }
+
+  /** Only for numeric fields. Minimum numeric value for a field */
+  public long getMin() {
+    return min;
+  }
+
+  /** Only for numeric fields. Sum of values for the field */
+  public long getSum() {
+    return sum;
+  }
+
+  /**
+   * Conversion utility to create {@link FacetStats} from server response
+   *
+   * @param resp {@link Api.FacetStats}
+   */
+  static FacetStats from(Api.FacetStats resp) {
+    Objects.requireNonNull(resp);
+
+    return new FacetStats(
+        resp.getAvg(), resp.getCount(), resp.getMax(), resp.getMin(), resp.getSum());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    FacetStats that = (FacetStats) o;
+
+    if (Double.compare(that.avg, avg) != 0) {
+      return false;
+    }
+    if (count != that.count) {
+      return false;
+    }
+    if (max != that.max) {
+      return false;
+    }
+    if (min != that.min) {
+      return false;
+    }
+    return sum == that.sum;
+  }
+
+  @Override
+  public int hashCode() {
+    int result;
+    long temp;
+    temp = Double.doubleToLongBits(avg);
+    result = (int) (temp ^ (temp >>> 32));
+    result = 31 * result + (int) (count ^ (count >>> 32));
+    result = 31 * result + (int) (max ^ (max >>> 32));
+    result = 31 * result + (int) (min ^ (min >>> 32));
+    result = 31 * result + (int) (sum ^ (sum >>> 32));
+    return result;
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/search/Hit.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/Hit.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import static java.lang.String.format;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tigrisdata.db.api.v1.grpc.Api;
+import com.tigrisdata.db.type.TigrisCollectionType;
+import java.util.Objects;
+
+/**
+ * Representation of {@link Api.SearchHit} that provides collection document and associated metadata
+ * from /search result
+ *
+ * @param <T> {@link TigrisCollectionType} type
+ */
+public final class Hit<T extends TigrisCollectionType> {
+
+  private final T document;
+  private final HitMeta meta;
+
+  private Hit(T document, HitMeta meta) {
+    this.document = document;
+    this.meta = meta;
+  }
+
+  /** Json deserialized document as its collection class */
+  public T getDocument() {
+    return document;
+  }
+
+  /** Relevance metadata for matched document */
+  public HitMeta getMeta() {
+    return meta;
+  }
+
+  /**
+   * Conversion utility for creating {@link Hit} from server response
+   *
+   * @param resp {@link Api.SearchHit} from server response
+   * @param objectMapper JSON deserializer
+   * @param collectionClass Deserialize document to this schema class
+   * @param <R> Tigris collection class type
+   */
+  static <R extends TigrisCollectionType> Hit<R> from(
+      Api.SearchHit resp, ObjectMapper objectMapper, Class<R> collectionClass) {
+    Objects.requireNonNull(resp);
+    try {
+      return new Hit<>(
+          objectMapper.readValue(resp.getData().toStringUtf8(), collectionClass),
+          HitMeta.from(resp.getMeta()));
+    } catch (JsonProcessingException e) {
+      throw new IllegalArgumentException(
+          format("Failed to convert response to %s.class", collectionClass.getSimpleName()), e);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    Hit<?> hit = (Hit<?>) o;
+
+    if (!Objects.equals(document, hit.document)) {
+      return false;
+    }
+    return Objects.equals(meta, hit.meta);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = document != null ? document.hashCode() : 0;
+    result = 31 * result + (meta != null ? meta.hashCode() : 0);
+    return result;
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/search/HitMeta.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/HitMeta.java
@@ -11,7 +11,22 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tigrisdata.db.client;
 
-/** Represents the filter */
-public interface TigrisFilter extends JSONSerializable {}
+package com.tigrisdata.db.client.search;
+
+import com.tigrisdata.db.api.v1.grpc.Api;
+import java.util.Objects;
+
+/**
+ * Representation of {@link Api.SearchHitMeta} exposing relevance information for the matched
+ * document.
+ */
+public final class HitMeta {
+  // TODO: Implement once API structure is finalized
+  private static final HitMeta DEFAULT_INSTANCE = new HitMeta();
+
+  static HitMeta from(Api.SearchHitMeta resp) {
+    Objects.requireNonNull(resp);
+    return DEFAULT_INSTANCE;
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/search/Query.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/Query.java
@@ -11,7 +11,9 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tigrisdata.db.client;
 
-/** Represents the filter */
-public interface TigrisFilter extends JSONSerializable {}
+package com.tigrisdata.db.client.search;
+
+import com.tigrisdata.db.client.JSONSerializable;
+
+public interface Query extends JSONSerializable {}

--- a/client/src/main/java/com/tigrisdata/db/client/search/QueryString.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/QueryString.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Objects;
+
+/** Data class for "string" based /search queries */
+public final class QueryString implements Query {
+  private static final String MATCH_ALL_STRING = "";
+  private static final QueryString MATCH_ALL_QUERY = new QueryString(MATCH_ALL_STRING);
+
+  private final String q;
+
+  private QueryString(String q) {
+    this.q = q;
+  }
+
+  /**
+   * Perform a placeholder search. Returns all searchable documents, modified by any other search
+   * parameters used.
+   */
+  public static QueryString getMatchAllQuery() {
+    return MATCH_ALL_QUERY;
+  }
+
+  /** Get query string */
+  public String getQ() {
+    return q;
+  }
+
+  @Override
+  public String toJSON(ObjectMapper objectMapper) {
+    return q;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    QueryString that = (QueryString) o;
+
+    return Objects.equals(q, that.q);
+  }
+
+  @Override
+  public int hashCode() {
+    return q != null ? q.hashCode() : 0;
+  }
+
+  /**
+   * Builder object to build {@link QueryString}
+   *
+   * @param q Query string
+   */
+  public static Builder newBuilder(String q) {
+    return new Builder(q);
+  }
+
+  public static final class Builder {
+
+    private String q;
+
+    private Builder(String searchString) {
+      this.q = searchString;
+    }
+
+    /** Builds a {@link QueryString} */
+    public QueryString build() {
+      if (q == null) {
+        q = MATCH_ALL_STRING;
+      }
+      return new QueryString(this.q);
+    }
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/search/SearchFields.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SearchFields.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tigrisdata.db.client.JSONSerializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Container for schema fields to project the search query */
+public final class SearchFields implements JSONSerializable {
+
+  private static final SearchFields EMPTY = newBuilder().build();
+  private final List<String> fields;
+
+  private SearchFields(Builder builder) {
+    this.fields = Collections.unmodifiableList(builder.fields);
+  }
+
+  /**
+   * Represents empty Search Field projection, server will project search query against all
+   * searchable fields
+   *
+   * @return an empty {@link SearchFields}
+   */
+  public static SearchFields empty() {
+    return EMPTY;
+  }
+
+  /** @return non-null immutable {@link List} of fields in this object */
+  public List<String> getFields() {
+    return this.fields;
+  }
+
+  @Override
+  public String toJSON(ObjectMapper objectMapper) {
+    try {
+      return objectMapper.writeValueAsString(fields);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(
+          "This was caused because the SearchFields's JSON serialization raised errors", e);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SearchFields that = (SearchFields) o;
+    return Objects.equals(fields, that.getFields());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(fields);
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+
+    private List<String> fields;
+
+    private Builder() {}
+
+    /**
+     * Field to project search query against
+     *
+     * @param field schema field name as string
+     */
+    public Builder withField(String field) {
+      if (this.fields == null) {
+        this.fields = new ArrayList<>();
+      }
+      this.fields.add(field);
+      return this;
+    }
+
+    /**
+     * Schema fields to project search query against
+     *
+     * @param fields list of schema field names as string
+     */
+    public Builder withFields(Collection<? extends String> fields) {
+      if (this.fields == null) {
+        this.fields = new ArrayList<>();
+      }
+      this.fields.addAll(fields);
+      return this;
+    }
+
+    /** Builds a {@link SearchFields} */
+    public SearchFields build() {
+      if (this.fields == null) {
+        this.fields = Collections.emptyList();
+      }
+      return new SearchFields(this);
+    }
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/search/SearchMeta.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SearchMeta.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.tigrisdata.db.api.v1.grpc.Api;
+import java.util.Objects;
+
+/** Representation of {@link Api.SearchMetadata}, information associated with /search results */
+public final class SearchMeta {
+
+  private final long found;
+  private final long currentPage;
+  private final long totalPages;
+  private final int perPage;
+
+  private SearchMeta(long found, long currentPage, long totalPages, int perPage) {
+    this.found = found;
+    this.currentPage = currentPage;
+    this.totalPages = totalPages;
+    this.perPage = perPage;
+  }
+
+  /** Total number of matches for the search query */
+  public long getFound() {
+    return found;
+  }
+
+  /** Current page number for the paginated search results */
+  public long getCurrentPage() {
+    return currentPage;
+  }
+
+  /** Total number pages for the search results */
+  public long getTotalPages() {
+    return totalPages;
+  }
+
+  /** Number of search results displayed per page */
+  public int getPerPage() {
+    return perPage;
+  }
+
+  /**
+   * Conversion utility to create {@link SearchMeta} from server response
+   *
+   * @param resp {@link Api.SearchMetadata}
+   */
+  static SearchMeta from(Api.SearchMetadata resp) {
+    Objects.requireNonNull(resp);
+    Api.Page page = resp.getPage();
+    return new SearchMeta(resp.getFound(), page.getCurrent(), page.getTotal(), page.getPerPage());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SearchMeta that = (SearchMeta) o;
+
+    if (found != that.found) {
+      return false;
+    }
+    if (currentPage != that.currentPage) {
+      return false;
+    }
+    if (totalPages != that.totalPages) {
+      return false;
+    }
+    return perPage == that.perPage;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (int) (found ^ (found >>> 32));
+    result = 31 * result + (int) (currentPage ^ (currentPage >>> 32));
+    result = 31 * result + (int) (totalPages ^ (totalPages >>> 32));
+    result = 31 * result + perPage;
+    return result;
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.tigrisdata.db.client.ReadFields;
+import com.tigrisdata.db.client.TigrisFilter;
+import java.util.Objects;
+
+/** Builder to create /search request */
+public final class SearchRequest {
+
+  private final Query query;
+  private final SearchFields searchFields;
+  private final TigrisFilter filter;
+  private final FacetQuery facetQuery;
+  private final SortOrders sortOrders;
+  private final ReadFields readFields;
+
+  private SearchRequest(Builder builder) {
+    this.query = builder.query;
+    this.filter = builder.filter;
+    this.searchFields = builder.searchFields;
+    this.facetQuery = builder.facetQuery;
+    this.sortOrders = builder.sortOrders;
+    this.readFields = builder.fields;
+  }
+
+  /**
+   * Builder API for {@link SearchRequest}
+   *
+   * @param query - Search query
+   * @return {@link SearchRequest.Builder}
+   */
+  public static Builder newBuilder(Query query) {
+    return new Builder(query);
+  }
+
+  /** Search query */
+  public Query getQuery() {
+    return query;
+  }
+
+  /** Fields on which the search query is projected */
+  public SearchFields getSearchFields() {
+    return this.searchFields;
+  }
+
+  /** Filters to further refine search results */
+  public TigrisFilter getFilter() {
+    return filter;
+  }
+
+  /** Facet query to categorically arrange the indexed terms */
+  public FacetQuery getFacetQuery() {
+    return facetQuery;
+  }
+
+  /** Order for ordering the search results */
+  public SortOrders getSortOrders() {
+    return sortOrders;
+  }
+
+  /** Document fields to include/exclude in search results */
+  public ReadFields getReadFields() {
+    return readFields;
+  }
+
+  public static final class Builder {
+
+    private final Query query;
+    private TigrisFilter filter;
+    private SearchFields searchFields;
+    private FacetQuery facetQuery;
+    private SortOrders sortOrders;
+    private ReadFields fields;
+
+    private Builder(Query query) {
+      this.query = query;
+    }
+
+    /** Optional fields to project search query */
+    public Builder withSearchFields(SearchFields fields) {
+      this.searchFields = fields;
+      return this;
+    }
+    /** Optional filters to further refine search results */
+    public Builder withFilter(TigrisFilter filter) {
+      this.filter = filter;
+      return this;
+    }
+    /** Optional facet query to categorically arrange the indexed terms */
+    public Builder withFacetQuery(FacetQuery facetQuery) {
+      this.facetQuery = facetQuery;
+      return this;
+    }
+    /** Optional order for ordering the search results */
+    public Builder withSortOrders(SortOrders sortOrders) {
+      this.sortOrders = sortOrders;
+      return this;
+    }
+
+    /** Optional document fields to include/exclude in search results */
+    public Builder withReadFields(ReadFields fields) {
+      this.fields = fields;
+      return this;
+    }
+
+    /**
+     * Builds a {@link SearchRequest}
+     *
+     * @throws NullPointerException if query is missing
+     */
+    public SearchRequest build() {
+      Objects.requireNonNull(this.query);
+      return new SearchRequest(this);
+    }
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/search/SearchRequestOptions.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SearchRequestOptions.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+/** Pagination options for search request */
+public final class SearchRequestOptions {
+  private static final long CURRENT_PAGE = 1;
+  private static final long DEFAULT_PER_PAGE = 10;
+  private static final SearchRequestOptions DEFAULT_INSTANCE = newBuilder().build();
+
+  private final long page;
+  private final long perPage;
+
+  private SearchRequestOptions(Builder builder) {
+    this.page = builder.page;
+    this.perPage = builder.perPage;
+  }
+
+  /** Results from this specific page number would be fetched */
+  public long getPage() {
+    return page;
+  }
+
+  /** Number of results to fetch per page */
+  public long getPerPage() {
+    return perPage;
+  }
+
+  /**
+   * Get default pagination options
+   * <li>Page numbers start at `1` for first page
+   * <li>By default 10 results will be fetched per page
+   */
+  public static SearchRequestOptions getDefault() {
+    return DEFAULT_INSTANCE;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SearchRequestOptions that = (SearchRequestOptions) o;
+
+    if (page != that.page) {
+      return false;
+    }
+    return perPage == that.perPage;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = (int) (page ^ (page >>> 32));
+    result = 31 * result + (int) (perPage ^ (perPage >>> 32));
+    return result;
+  }
+
+  /** Builder API for {@link SearchRequestOptions} */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private long page;
+    private long perPage;
+
+    private Builder() {
+      this.page = CURRENT_PAGE;
+      this.perPage = DEFAULT_PER_PAGE;
+    }
+
+    /** Results from this page number will be fetched */
+    public Builder withPage(long page) {
+      this.page = page;
+      return this;
+    }
+
+    /** Number of results to fetch per page */
+    public Builder withPerPage(long perPage) {
+      this.perPage = perPage;
+      return this;
+    }
+
+    /** Builds {@link SearchRequestOptions} */
+    public SearchRequestOptions build() {
+      return new SearchRequestOptions(this);
+    }
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/search/SearchResult.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SearchResult.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tigrisdata.db.api.v1.grpc.Api;
+import com.tigrisdata.db.type.TigrisCollectionType;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Outcome of executing /search query against server
+ * <li>Representation of {@link Api.SearchResponse} from server
+ * </ul>
+ *
+ * @param <T> type of the Tigris collection
+ */
+public final class SearchResult<T extends TigrisCollectionType> {
+
+  private final List<Hit<T>> hits;
+  private final Map<String, FacetCountDistribution> facets;
+  private final SearchMeta meta;
+
+  public SearchResult(
+      List<Hit<T>> hits, Map<String, FacetCountDistribution> facets, SearchMeta meta) {
+    this.hits = Collections.unmodifiableList(hits);
+    this.facets = Collections.unmodifiableMap(facets);
+    this.meta = meta;
+  }
+
+  /** Results of the query as a list */
+  public List<Hit<T>> getHits() {
+    return hits;
+  }
+
+  /** Distribution of the facets provided as part of the facet query */
+  public Map<String, FacetCountDistribution> getFacets() {
+    return facets;
+  }
+
+  /** Information about {@link SearchResult} */
+  public SearchMeta getMeta() {
+    return meta;
+  }
+
+  /**
+   * Conversion utility for creating {@link SearchResult} from server response
+   *
+   * @param resp {@link Api.SearchResponse} from server
+   * @param objectMapper JSON deserializer
+   * @param collectionClass Deserialize document to this schema class
+   * @param <R> Tigris collection class type
+   */
+  public static <R extends TigrisCollectionType> SearchResult<R> from(
+      Api.SearchResponse resp, ObjectMapper objectMapper, Class<R> collectionClass) {
+    Objects.requireNonNull(resp);
+
+    List<Hit<R>> hits =
+        resp.getHitsList().stream()
+            .map(h -> Hit.from(h, objectMapper, collectionClass))
+            .collect(Collectors.toList());
+
+    // proto inserts a default entry
+    Map<String, FacetCountDistribution> facets =
+        resp.getFacetsMap().entrySet().stream()
+            .collect(
+                Collectors.toMap(Entry::getKey, e -> FacetCountDistribution.from(e.getValue())));
+
+    return new SearchResult<>(hits, facets, SearchMeta.from(resp.getMeta()));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SearchResult<?> that = (SearchResult<?>) o;
+
+    if (!Objects.equals(hits, that.hits)) {
+      return false;
+    }
+    if (!Objects.equals(facets, that.facets)) {
+      return false;
+    }
+    return Objects.equals(meta, that.meta);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = hits != null ? hits.hashCode() : 0;
+    result = 31 * result + (facets != null ? facets.hashCode() : 0);
+    result = 31 * result + (meta != null ? meta.hashCode() : 0);
+    return result;
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/search/SortOrders.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SortOrders.java
@@ -11,7 +11,9 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tigrisdata.db.client;
 
-/** Represents the filter */
-public interface TigrisFilter extends JSONSerializable {}
+package com.tigrisdata.db.client.search;
+
+import com.tigrisdata.db.client.JSONSerializable;
+
+public interface SortOrders extends JSONSerializable {}

--- a/client/src/test/java/com/tigrisdata/db/client/TypeConverterTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/TypeConverterTest.java
@@ -11,34 +11,46 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.tigrisdata.db.client;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.Any;
 import com.google.rpc.Code;
 import com.google.rpc.ErrorInfo;
 import com.google.rpc.Status;
 import com.tigrisdata.db.api.v1.grpc.Api;
+import com.tigrisdata.db.client.config.TigrisConfiguration;
 import com.tigrisdata.db.client.error.TigrisError;
 import com.tigrisdata.db.client.error.TigrisException;
+import com.tigrisdata.db.client.search.QueryString;
+import com.tigrisdata.db.client.search.SearchRequest;
 import io.grpc.StatusRuntimeException;
 import io.grpc.protobuf.StatusProto;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class TypeConverterTest {
+
+  private static final String DB_NAME = "db1";
+  private static final String COLLECTION_NAME = "coll1";
+  private static final ObjectMapper DEFAULT_OBJECT_MAPPER =
+      TigrisConfiguration.newBuilder("test").build().getObjectMapper();
+
   @Test
   public void apiDatabaseInfoToModelTest() {
     DatabaseInfo convertedDatabaseInfo1 =
-        TypeConverter.toDatabaseInfo(Api.DatabaseInfo.newBuilder().setDb("db1").build());
-    DatabaseInfo databaseInfo1 = new DatabaseInfo("db1");
+        TypeConverter.toDatabaseInfo(Api.DatabaseInfo.newBuilder().setDb(DB_NAME).build());
+    DatabaseInfo databaseInfo1 = new DatabaseInfo(DB_NAME);
     Assert.assertEquals(convertedDatabaseInfo1, databaseInfo1);
   }
 
   @Test
   public void apiCollectionInfoToModelTest() {
     CollectionInfo convertedCollectionInfo1 =
-        TypeConverter.toCollectionInfo(Api.CollectionInfo.newBuilder().setCollection("c1").build());
-    CollectionInfo collectionInfo1 = new CollectionInfo("c1");
+        TypeConverter.toCollectionInfo(
+            Api.CollectionInfo.newBuilder().setCollection(COLLECTION_NAME).build());
+    CollectionInfo collectionInfo1 = new CollectionInfo(COLLECTION_NAME);
     Assert.assertEquals(convertedCollectionInfo1, collectionInfo1);
   }
 
@@ -46,7 +58,7 @@ public class TypeConverterTest {
   public void unreadableSchemaCreateCollectionRequestConversionTest() {
     try {
       TypeConverter.toCreateCollectionRequest(
-          "db1", new TigrisJSONSchema("invalid-schema"), CollectionOptions.DEFAULT_INSTANCE);
+          DB_NAME, new TigrisJSONSchema("invalid-schema"), CollectionOptions.DEFAULT_INSTANCE);
       Assert.fail("This must fail");
     } catch (TigrisException ignore) {
     }
@@ -66,5 +78,20 @@ public class TypeConverterTest {
     StatusRuntimeException statusRuntimeException = StatusProto.toStatusRuntimeException(status);
     TigrisError tigrisError = TypeConverter.extractTigrisError(statusRuntimeException).get();
     Assert.assertEquals(Api.Code.DEADLINE_EXCEEDED, tigrisError.getCode());
+  }
+
+  @Test
+  public void toSearchRequest() {
+    SearchRequest input =
+        SearchRequest.newBuilder(QueryString.newBuilder("search str").build()).build();
+    Api.SearchRequest apiSearchRequest =
+        TypeConverter.toSearchRequest(DB_NAME, COLLECTION_NAME, input, DEFAULT_OBJECT_MAPPER);
+
+    Assert.assertEquals(input.getQuery().toJSON(DEFAULT_OBJECT_MAPPER), apiSearchRequest.getQ());
+    Assert.assertNotNull(apiSearchRequest.getSearchFieldsList());
+    Assert.assertNotNull(apiSearchRequest.getFacet());
+    Assert.assertNotNull(apiSearchRequest.getFilter());
+    Assert.assertNotNull(apiSearchRequest.getSort());
+    Assert.assertNotNull(apiSearchRequest.getFields());
   }
 }

--- a/client/src/test/java/com/tigrisdata/db/client/search/FacetCountDistributionTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/FacetCountDistributionTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.tigrisdata.db.api.v1.grpc.Api;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FacetCountDistributionTest {
+
+  @Test
+  public void convert() {
+    Api.FacetStats stats = Api.FacetStats.newBuilder().setCount(12).build();
+    Api.SearchFacet resp =
+        Api.SearchFacet.newBuilder()
+            .setStats(stats)
+            .addCounts(Api.FacetCount.newBuilder().setValue("name").setCount(2))
+            .build();
+    FacetCountDistribution actual = FacetCountDistribution.from(resp);
+
+    Assert.assertNotNull(actual.getCounts());
+    Assert.assertNotNull(actual.getStats());
+
+    Assert.assertEquals(resp.getCounts(0).getValue(), actual.getCounts().get(0).getValue());
+    Assert.assertEquals(resp.getCounts(0).getCount(), actual.getCounts().get(0).getCount());
+
+    Assert.assertEquals(stats.getCount(), actual.getStats().getCount());
+  }
+
+  @Test
+  public void convertWithNullValues() {
+    Api.SearchFacet resp = Api.SearchFacet.newBuilder().build();
+    FacetCountDistribution actual = FacetCountDistribution.from(resp);
+
+    Assert.assertNotNull(actual.getCounts());
+    Assert.assertNotNull(actual.getStats());
+  }
+
+  @Test
+  public void convertFromNull() {
+    Assert.assertThrows(NullPointerException.class, () -> FacetCountDistribution.from(null));
+  }
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(FacetCountDistribution.class).verify();
+  }
+}

--- a/client/src/test/java/com/tigrisdata/db/client/search/FacetCountTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/FacetCountTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.tigrisdata.db.api.v1.grpc.Api;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FacetCountTest {
+
+  @Test
+  public void convert() {
+    Api.FacetCount resp = Api.FacetCount.newBuilder().setValue("Shoe").setCount(32).build();
+    FacetCount actual = FacetCount.from(resp);
+    Assert.assertEquals(resp.getValue(), actual.getValue());
+    Assert.assertEquals(resp.getCount(), actual.getCount());
+  }
+
+  @Test
+  public void convertFromNull() {
+    Assert.assertThrows(NullPointerException.class, () -> FacetCount.from(null));
+  }
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(FacetCount.class).verify();
+  }
+}

--- a/client/src/test/java/com/tigrisdata/db/client/search/FacetFieldsQueryTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/FacetFieldsQueryTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tigrisdata.db.client.config.TigrisConfiguration;
+import java.util.Collections;
+import java.util.Map;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FacetFieldsQueryTest {
+
+  private static final ObjectMapper DEFAULT_OBJECT_MAPPER =
+      TigrisConfiguration.newBuilder("test").build().getObjectMapper();
+
+  @Test
+  public void empty() {
+    FacetFieldsQuery fields = FacetFieldsQuery.empty();
+    Assert.assertTrue(fields.isEmpty());
+  }
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(FacetFieldsQuery.class).verify();
+  }
+
+  @Test
+  public void buildWithFields() {
+    Map<String, FacetQueryOptions> optionsMap =
+        Collections.singletonMap("someField", FacetQueryOptions.newBuilder().withLimit(30).build());
+    FacetFieldsQuery fields = FacetFieldsQuery.newBuilder().addAll(optionsMap).build();
+    Assert.assertEquals(optionsMap, fields.getFacetFields());
+  }
+
+  @Test
+  public void buildWithOptions() {
+    FacetFieldsQuery query =
+        FacetFieldsQuery.newBuilder()
+            .withFieldOptions("name", FacetQueryOptions.newBuilder().withLimit(20).build())
+            .build();
+    Assert.assertTrue(query.getFacetFields().containsKey("name"));
+  }
+
+  @Test
+  public void toJSONSerialization() {
+    Map<String, FacetQueryOptions> optionsMap =
+        Collections.singletonMap("someField", FacetQueryOptions.newBuilder().withLimit(30).build());
+    FacetFieldsQuery input = FacetFieldsQuery.newBuilder().addAll(optionsMap).build();
+    String expected = "{\"someField\":{\"type\":\"value\",\"limit\":30}}";
+    Assert.assertEquals(expected, input.toJSON(DEFAULT_OBJECT_MAPPER));
+  }
+
+  @Test
+  public void toJSONSerializationFailure() {
+    FacetFieldsQuery fields = FacetFieldsQuery.empty();
+    try {
+      fields.toJSON(
+          new ObjectMapper() {
+            @Override
+            public String writeValueAsString(Object value) throws JsonProcessingException {
+              throw new JsonParseException(null, "");
+            }
+          });
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals("Failed to serialize FacetFields to JSON", e.getMessage());
+    }
+  }
+}

--- a/client/src/test/java/com/tigrisdata/db/client/search/FacetQueryOptionsTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/FacetQueryOptionsTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tigrisdata.db.client.config.TigrisConfiguration;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FacetQueryOptionsTest {
+
+  private static final ObjectMapper DEFAULT_OBJECT_MAPPER =
+      TigrisConfiguration.newBuilder("test").build().getObjectMapper();
+
+  @Test
+  public void defaultInstance() {
+    FacetQueryOptions expected =
+        FacetQueryOptions.newBuilder().withType(FacetFieldType.value).withLimit(10).build();
+    FacetQueryOptions actual = FacetQueryOptions.getDefaultInstance();
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void withNullType() {
+    FacetQueryOptions actual = FacetQueryOptions.newBuilder().withType(null).withLimit(20).build();
+    Assert.assertEquals(FacetFieldType.value, actual.getType());
+    Assert.assertEquals(20, actual.getLimit());
+  }
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(FacetQueryOptions.class).verify();
+  }
+
+  @Test
+  public void toJSONSerialization() {
+    FacetQueryOptions options = FacetQueryOptions.newBuilder().withLimit(20).build();
+    String expected = "{\"limit\":\"20\",\"type\":\"value\"}";
+    String actual = options.toJSON(DEFAULT_OBJECT_MAPPER);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void toJSONSerializationFailure() {
+    FacetQueryOptions options = FacetQueryOptions.getDefaultInstance();
+    try {
+      options.toJSON(
+          new ObjectMapper() {
+            @Override
+            public String writeValueAsString(Object value) throws JsonProcessingException {
+              throw new JsonParseException(null, "");
+            }
+          });
+    } catch (IllegalArgumentException e) {
+      Assert.assertEquals("Failed to serialize FacetFieldOption to JSON", e.getMessage());
+    }
+  }
+}

--- a/client/src/test/java/com/tigrisdata/db/client/search/FacetStatsTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/FacetStatsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.tigrisdata.db.api.v1.grpc.Api;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FacetStatsTest {
+
+  @Test
+  public void convert() {
+    Api.FacetStats resp =
+        Api.FacetStats.newBuilder()
+            .setCount(12)
+            .setAvg(8.2f)
+            .setMax(40)
+            .setMin(2)
+            .setSum(120)
+            .build();
+    FacetStats actual = FacetStats.from(resp);
+    Assert.assertEquals(resp.getAvg(), actual.getAvg(), 0);
+    Assert.assertEquals(resp.getCount(), actual.getCount());
+    Assert.assertEquals(resp.getSum(), actual.getSum());
+    Assert.assertEquals(resp.getMax(), actual.getMax());
+    Assert.assertEquals(resp.getMin(), actual.getMin());
+  }
+
+  @Test
+  public void convertFromNull() {
+    Assert.assertThrows(NullPointerException.class, () -> FacetStats.from(null));
+  }
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(FacetStats.class).verify();
+  }
+}

--- a/client/src/test/java/com/tigrisdata/db/client/search/HitMetaTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/HitMetaTest.java
@@ -11,7 +11,16 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.tigrisdata.db.client;
 
-/** Represents the filter */
-public interface TigrisFilter extends JSONSerializable {}
+package com.tigrisdata.db.client.search;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HitMetaTest {
+
+  @Test
+  public void fromNull() {
+    Assert.assertThrows(NullPointerException.class, () -> HitMeta.from(null));
+  }
+}

--- a/client/src/test/java/com/tigrisdata/db/client/search/HitTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/HitTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
+import com.tigrisdata.db.api.v1.grpc.Api;
+import com.tigrisdata.db.client.collection.DB1_C1;
+import com.tigrisdata.db.client.config.TigrisConfiguration;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HitTest {
+
+  private static final ObjectMapper DEFAULT_OBJECT_MAPPER =
+      TigrisConfiguration.newBuilder("test").build().getObjectMapper();
+
+  // TODO: Add deserialization for meta as well
+  @Test
+  public void fromNull() {
+    Assert.assertThrows(
+        NullPointerException.class, () -> Hit.from(null, DEFAULT_OBJECT_MAPPER, DB1_C1.class));
+  }
+
+  @Test
+  public void deserialization() {
+    String data = "{\"id\":0,\"name\":\"db1_c1_d0\"}";
+    Api.SearchHit input = Api.SearchHit.newBuilder().setData(ByteString.copyFromUtf8(data)).build();
+    Hit<DB1_C1> hit = Hit.from(input, DEFAULT_OBJECT_MAPPER, DB1_C1.class);
+    Assert.assertNotNull(hit);
+    Assert.assertEquals(DB1_C1.class, hit.getDocument().getClass());
+    Assert.assertEquals(0, hit.getDocument().getId());
+    Assert.assertEquals("db1_c1_d0", hit.getDocument().getName());
+  }
+
+  @Test
+  public void deserializationFailure() {
+    Api.SearchHit input =
+        Api.SearchHit.newBuilder().setData(ByteString.copyFromUtf8("data")).build();
+    Exception thrown =
+        Assert.assertThrows(
+            IllegalArgumentException.class,
+            () -> Hit.from(input, DEFAULT_OBJECT_MAPPER, DB1_C1.class));
+    Assert.assertEquals("Failed to convert response to DB1_C1.class", thrown.getMessage());
+  }
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(Hit.class).verify();
+  }
+}

--- a/client/src/test/java/com/tigrisdata/db/client/search/QueryStringTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/QueryStringTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tigrisdata.db.client.config.TigrisConfiguration;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class QueryStringTest {
+  private static final ObjectMapper DEFAULT_OBJECT_MAPPER =
+      TigrisConfiguration.newBuilder("test").build().getObjectMapper();
+
+  @Test
+  public void matchAll() {
+    Assert.assertEquals("", QueryString.getMatchAllQuery().getQ());
+  }
+
+  @Test
+  public void toJSONSerialization() {
+    QueryString queryString = QueryString.newBuilder("some query").build();
+    Assert.assertEquals("some query", queryString.toJSON(DEFAULT_OBJECT_MAPPER));
+  }
+
+  @Test
+  public void buildWithNull() {
+    QueryString queryString = QueryString.newBuilder(null).build();
+    Assert.assertNotNull(queryString.getQ());
+    Assert.assertEquals("", queryString.getQ());
+  }
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(QueryString.class).verify();
+  }
+}

--- a/client/src/test/java/com/tigrisdata/db/client/search/SearchFieldsTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/SearchFieldsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import static java.util.Collections.emptyList;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tigrisdata.db.client.config.TigrisConfiguration;
+import java.util.Arrays;
+import java.util.List;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SearchFieldsTest {
+
+  private static final ObjectMapper DEFAULT_OBJECT_MAPPER =
+      TigrisConfiguration.newBuilder("test").build().getObjectMapper();
+
+  @Test
+  public void emptySearchFields() {
+    Assert.assertTrue(SearchFields.empty().getFields().isEmpty());
+  }
+
+  @Test
+  public void searchFieldsIsEmpty() {
+    SearchFields actual = SearchFields.newBuilder().withFields(emptyList()).build();
+    Assert.assertTrue(actual.getFields().isEmpty());
+  }
+
+  @Test
+  public void builderAddOne() {
+    String expected = "someField";
+    SearchFields actual = SearchFields.newBuilder().withField(expected).build();
+    Assert.assertEquals(1, actual.getFields().size());
+    Assert.assertTrue(actual.getFields().contains(expected));
+  }
+
+  @Test
+  public void builderAddAll() {
+    List<String> expected = Arrays.asList("firstField", "secondField");
+    SearchFields actual = SearchFields.newBuilder().withFields(expected).build();
+    Assert.assertEquals(expected.size(), actual.getFields().size());
+    Assert.assertTrue(actual.getFields().containsAll(expected));
+  }
+
+  @Test
+  public void toJSONSerialization() {
+    List<String> input = Arrays.asList("firstField", "secondField");
+    String actual =
+        SearchFields.newBuilder().withFields(input).build().toJSON(DEFAULT_OBJECT_MAPPER);
+    String expected = "[\"firstField\",\"secondField\"]";
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void toJSONSerializationFailure() {
+    SearchFields fields = SearchFields.empty();
+    Exception thrown =
+        Assert.assertThrows(
+            IllegalStateException.class,
+            () ->
+                fields.toJSON(
+                    new ObjectMapper() {
+                      @Override
+                      public String writeValueAsString(Object value)
+                          throws JsonProcessingException {
+                        throw new JsonParseException(null, "");
+                      }
+                    }));
+    Assert.assertEquals(
+        "This was caused because the SearchFields's JSON serialization raised errors",
+        thrown.getMessage());
+  }
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(SearchFields.class).verify();
+  }
+}

--- a/client/src/test/java/com/tigrisdata/db/client/search/SearchMetaTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/SearchMetaTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.tigrisdata.db.api.v1.grpc.Api;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SearchMetaTest {
+
+  @Test
+  public void convert() {
+    Api.Page page = Api.Page.newBuilder().setPerPage(21).setCurrent(2).setTotal(90).build();
+    Api.SearchMetadata resp = Api.SearchMetadata.newBuilder().setFound(1900).setPage(page).build();
+    SearchMeta actual = SearchMeta.from(resp);
+    Assert.assertEquals(resp.getFound(), actual.getFound());
+    Assert.assertEquals(page.getPerPage(), actual.getPerPage());
+    Assert.assertEquals(page.getCurrent(), actual.getCurrentPage());
+    Assert.assertEquals(page.getTotal(), actual.getTotalPages());
+  }
+
+  @Test
+  public void convertFromNull() {
+    Assert.assertThrows(NullPointerException.class, () -> SearchMeta.from(null));
+  }
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(SearchMeta.class).verify();
+  }
+}

--- a/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestOptionsTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestOptionsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SearchRequestOptionsTest {
+
+  @Test
+  public void build() {
+    SearchRequestOptions options =
+        SearchRequestOptions.newBuilder().withPage(5).withPerPage(20).build();
+    Assert.assertEquals(5, options.getPage());
+    Assert.assertEquals(20, options.getPerPage());
+  }
+
+  @Test
+  public void getDefault() {
+    SearchRequestOptions options = SearchRequestOptions.getDefault();
+    Assert.assertEquals(1, options.getPage());
+    Assert.assertEquals(10, options.getPerPage());
+  }
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(SearchRequestOptions.class).verify();
+  }
+}

--- a/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.tigrisdata.db.client.Filters;
+import com.tigrisdata.db.client.ReadFields;
+import com.tigrisdata.db.client.TigrisFilter;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SearchRequestTest {
+
+  // TODO: Add sort orders to this test
+  @Test
+  public void build() {
+    Query expectedQuery = QueryString.getMatchAllQuery();
+    SearchFields expectedSearchFields = SearchFields.newBuilder().withField("field_1").build();
+    TigrisFilter expectedFilter = Filters.eq("field_2", "otherValue");
+    FacetQuery expectedFacetQuery = FacetFieldsQuery.newBuilder().withField("field_3").build();
+    ReadFields expectedReadFields = ReadFields.newBuilder().includeField("field_1").build();
+
+    SearchRequest actual =
+        SearchRequest.newBuilder(expectedQuery)
+            .withSearchFields(expectedSearchFields)
+            .withFacetQuery(expectedFacetQuery)
+            .withFilter(expectedFilter)
+            .withReadFields(expectedReadFields)
+            .build();
+
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(expectedQuery, actual.getQuery());
+    Assert.assertEquals(expectedSearchFields, actual.getSearchFields());
+    Assert.assertEquals(expectedFacetQuery, actual.getFacetQuery());
+    Assert.assertEquals(expectedFilter, actual.getFilter());
+    Assert.assertEquals(expectedReadFields, actual.getReadFields());
+    Assert.assertNull(actual.getSortOrders());
+  }
+
+  @Test
+  public void failsWithNullQuery() {
+    Assert.assertThrows(NullPointerException.class, () -> SearchRequest.newBuilder(null).build());
+  }
+}

--- a/client/src/test/java/com/tigrisdata/db/client/search/SearchResultTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/SearchResultTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.ByteString;
+import com.tigrisdata.db.api.v1.grpc.Api;
+import com.tigrisdata.db.client.collection.DB1_C1;
+import com.tigrisdata.db.client.config.TigrisConfiguration;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SearchResultTest {
+
+  private static final ObjectMapper DEFAULT_OBJECT_MAPPER =
+      TigrisConfiguration.newBuilder("test").build().getObjectMapper();
+
+  @Test
+  public void convert() {
+    String data = "{\"id\":0,\"name\":\"db1_c1_d0\"}";
+    Api.SearchHit actualSearchHit =
+        Api.SearchHit.newBuilder().setData(ByteString.copyFromUtf8(data)).build();
+    Api.SearchFacet actualFacet =
+        Api.SearchFacet.newBuilder()
+            .addCounts(Api.FacetCount.newBuilder().setValue("someValue").setCount(2))
+            .build();
+    Api.SearchMetadata actualMeta = Api.SearchMetadata.newBuilder().setFound(1900).build();
+    Api.SearchResponse resp =
+        Api.SearchResponse.newBuilder()
+            .addHits(actualSearchHit)
+            .putFacets("someField", actualFacet)
+            .setMeta(actualMeta)
+            .build();
+
+    SearchResult<DB1_C1> result = SearchResult.from(resp, DEFAULT_OBJECT_MAPPER, DB1_C1.class);
+
+    Assert.assertEquals(resp.getHitsList().size(), result.getHits().size());
+    Assert.assertTrue(result.getFacets().containsKey("someField"));
+    Assert.assertEquals(actualMeta.getFound(), result.getMeta().getFound());
+  }
+
+  @Test
+  public void convertFromDefault() {
+    Api.SearchResponse resp = Api.SearchResponse.newBuilder().build();
+    SearchResult<DB1_C1> result = SearchResult.from(resp, DEFAULT_OBJECT_MAPPER, DB1_C1.class);
+
+    Assert.assertNotNull(result);
+    Assert.assertNotNull(result.getHits());
+    Assert.assertEquals(0, result.getHits().size());
+    Assert.assertNotNull(result.getFacets());
+    Assert.assertEquals(0, result.getFacets().size());
+    Assert.assertNotNull(result.getMeta());
+  }
+
+  @Test
+  public void convertFromNull() {
+    Assert.assertThrows(
+        NullPointerException.class,
+        () -> SearchResult.from(null, DEFAULT_OBJECT_MAPPER, DB1_C1.class));
+  }
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(SearchResult.class).verify();
+  }
+}


### PR DESCRIPTION
### Search Request
```json
{
  "q": "Steve",
  "search_fields": [
    "first_name",
    "last_name"
  ],
  "filter": {
    "$or": [
      {
        "country": {
          "$eq": "USA"
        }
      },
      {
        "country": "UK"
      }
    ],
    "$and": [
      {
        "last_name": {
          "$ne": "Ballmer"
        }
      },
      {
        "last_updated": {
          "$gte": "2018-10-29 10:02:48"
        }
      },
      {
        "last_updated": {
          "$lt": "2020-10-29 10:02:48"
        }
      }
    ]
  },
  "facet": {
    "first_name": {
      "type": "value",
      "limit": 20
    }
  },
  "sort": [
    {
      "age": "$asc"
    },
    {
      "salary": "$desc"
    }
  ],
  "fields": []
}
```

### Search Response
```json
{
  "hits": [
    {
      "doc": {},
      "metadata": {}
    }
  ],
  "facet": {
    "field": {
      "counts": [],
      "stats": {}
    }
  },
  "meta": {
    "found": 12345,
    "page": {
      "current": 1,
      "total": 5,
      "per_page": 10
    }
  }
}
```
### Open q
- [x] How do we update the proto in client?
- [x] Async implementation
- [x] Any other work on transactions
- [x] Add search to failing user service?

### Pending
For next iteration
- Update api to latest revision (incremental search features)
- Async implementation
- Pagination (new api changes)
- Search hit meta (new api changes)
- Replace `ReadFields` implementation for search
- Read me update
- Tigris Documentation update
- Code samples doc update

Most of the request is open ended as of now and `pagination`, `facet` and `sort orders` are not finalized yet.