### PR TITLE
feat: Set inplace autoGenerated primary key values in input models

### DIFF
--- a/client/src/main/java/com/tigrisdata/db/client/InsertResponse.java
+++ b/client/src/main/java/com/tigrisdata/db/client/InsertResponse.java
@@ -22,7 +22,6 @@ import java.util.Map;
 /** Represents Server response for Insert operation */
 public class InsertResponse<T> extends DMLResponse {
   private final Map<String, Object>[] generatedKeys;
-  private final List<T> docs;
 
   InsertResponse(
       String status,
@@ -33,25 +32,16 @@ public class InsertResponse<T> extends DMLResponse {
       throws IllegalStateException {
     super(status, createdAt, updatedAt);
     this.generatedKeys = generatedKeys;
-    this.docs = docs;
     Utilities.fillInIds(docs, generatedKeys);
-  }
-
-  /**
-   * @return copy of the documents with their primary-keys set. This is useful to know when
-   *     primary-key is set to autoGenerate
-   */
-  public List<T> getDocs() {
-    return docs;
   }
 
   /**
    * @return an array of (Map of (String to Object)). Value in map is one of these types (int, long,
    *     UUID, String). The key of the map is the primaryKey field name in your collection and value
-   *     is the generated value for that. Array preserves the order in which the entries were
-   *     submitted for insertion.
+   *     is the either generated or already supplied value for that. Array preserves the order in
+   *     which the entries were submitted for insertion.
    */
-  public Map<String, Object>[] getGeneratedKeys() {
+  public Map<String, Object>[] getKeys() {
     return generatedKeys;
   }
 

--- a/client/src/main/java/com/tigrisdata/db/client/StandardTigrisCollection.java
+++ b/client/src/main/java/com/tigrisdata/db/client/StandardTigrisCollection.java
@@ -34,7 +34,6 @@ import com.tigrisdata.db.client.error.TigrisException;
 import com.tigrisdata.db.type.TigrisCollectionType;
 import io.grpc.StatusRuntimeException;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -152,7 +151,7 @@ class StandardTigrisCollection<T extends TigrisCollectionType> extends AbstractT
           response.getMetadata().getCreatedAt(),
           response.getMetadata().getUpdatedAt(),
           TypeConverter.toArrayOfMap(response.getKeysList(), objectMapper),
-          new ArrayList(documents));
+          documents);
     } catch (JsonProcessingException ex) {
       throw new TigrisException("Failed to serialize documents to JSON", ex);
     } catch (StatusRuntimeException statusRuntimeException) {
@@ -214,7 +213,7 @@ class StandardTigrisCollection<T extends TigrisCollectionType> extends AbstractT
           response.getMetadata().getCreatedAt(),
           response.getMetadata().getUpdatedAt(),
           TypeConverter.toArrayOfMap(response.getKeysList(), objectMapper),
-          new ArrayList(documents));
+          documents);
     } catch (JsonProcessingException ex) {
       throw new TigrisException("Failed to serialize to JSON", ex);
     } catch (StatusRuntimeException statusRuntimeException) {

--- a/client/src/main/java/com/tigrisdata/db/client/TigrisAsyncCollection.java
+++ b/client/src/main/java/com/tigrisdata/db/client/TigrisAsyncCollection.java
@@ -59,6 +59,12 @@ public interface TigrisAsyncCollection<T extends TigrisCollectionType>
   CompletableFuture<Optional<T>> readOne(TigrisFilter filter);
 
   /**
+   * Inserts documents into collection
+   *
+   * <p>Note: if your collection model has primary key that is tagged to autoGenerate values. The
+   * input list of documents will be modified to set the primary key fields after successful
+   * insertion.
+   *
    * @param documents list of documents to insert
    * @param insertRequestOptions insert option
    * @return a future to the {@link InsertResponse}
@@ -68,6 +74,12 @@ public interface TigrisAsyncCollection<T extends TigrisCollectionType>
       List<T> documents, InsertRequestOptions insertRequestOptions) throws TigrisException;
 
   /**
+   * Inserts documents into collection
+   *
+   * <p>Note: if your collection model has primary key that is tagged to autoGenerate values. The
+   * input list of documents will be modified to set the primary key fields after successful
+   * insertion.
+   *
    * @param documents list of documents to insert
    * @return a future to the {@link InsertResponse}
    * @throws TigrisException in case of an error
@@ -77,6 +89,10 @@ public interface TigrisAsyncCollection<T extends TigrisCollectionType>
   /**
    * inserts a single document to the collection
    *
+   * <p>Note: if your collection model has primary key that is tagged to autoGenerate values. The
+   * input list of documents will be modified to set the primary key fields after successful
+   * insertion.
+   *
    * @param document document to insert
    * @return a future to the {@link InsertResponse}
    * @throws TigrisException in case of an error
@@ -85,6 +101,10 @@ public interface TigrisAsyncCollection<T extends TigrisCollectionType>
 
   /**
    * Inserts the documents if they don't exist already, replaces them otherwise.
+   *
+   * <p>Note: if your collection model has primary key that is tagged to autoGenerate values. The
+   * input list of documents will be modified to set the primary key fields after successful
+   * insertion.
    *
    * @param documents list of documents to replace
    * @param insertOrReplaceRequestOptions option

--- a/client/src/main/java/com/tigrisdata/db/client/TigrisCollection.java
+++ b/client/src/main/java/com/tigrisdata/db/client/TigrisCollection.java
@@ -59,6 +59,12 @@ public interface TigrisCollection<T extends TigrisCollectionType>
   Optional<T> readOne(TigrisFilter filter) throws TigrisException;
 
   /**
+   * Inserts the documents into collection.
+   *
+   * <p>Note: if your collection model has primary key that is tagged to autoGenerate values. The
+   * input list of documents will be modified to set the primary key fields after successful
+   * insertion.
+   *
    * @param documents list of documents to insert
    * @param insertRequestOptions insert option
    * @return an instance of {@link InsertResponse} from server
@@ -68,6 +74,12 @@ public interface TigrisCollection<T extends TigrisCollectionType>
       throws TigrisException;
 
   /**
+   * Inserts the document into collection.
+   *
+   * <p>Note: if your collection model has primary key that is tagged to autoGenerate values. The
+   * input list of documents will be modified to set the primary key fields after successful
+   * insertion.
+   *
    * @param documents list of documents to insert
    * @return an instance of {@link InsertResponse} from server
    * @throws TigrisException in case of an error
@@ -76,6 +88,10 @@ public interface TigrisCollection<T extends TigrisCollectionType>
 
   /**
    * Inserts the documents if they don't exist already, replaces them otherwise.
+   *
+   * <p>Note: if your collection model has primary key that is tagged to autoGenerate values. The
+   * input list of documents will be modified to set the primary key fields after successful
+   * insertion.
    *
    * @param documents list of documents to replace
    * @param insertOrReplaceRequestOptions option
@@ -89,6 +105,10 @@ public interface TigrisCollection<T extends TigrisCollectionType>
   /**
    * Inserts the documents if they don't exist already, replaces them otherwise.
    *
+   * <p>Note: if your collection model has primary key that is tagged to autoGenerate values. The
+   * input list of documents will be modified to set the primary key fields after successful
+   * insertion.
+   *
    * @param documents list of documents to replace
    * @return an instance of {@link InsertOrReplaceResponse} from server
    * @throws TigrisException in case of an error
@@ -97,6 +117,10 @@ public interface TigrisCollection<T extends TigrisCollectionType>
 
   /**
    * inserts a single document to the collection
+   *
+   * <p>Note: if your collection model has primary key that is tagged to autoGenerate values. The
+   * input list of documents will be modified to set the primary key fields after successful
+   * insertion.
    *
    * @param document document to insert
    * @return an instance of InsertResponse

--- a/client/src/main/java/com/tigrisdata/db/client/Utilities.java
+++ b/client/src/main/java/com/tigrisdata/db/client/Utilities.java
@@ -19,6 +19,7 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.tigrisdata.db.annotation.TigrisCollection;
+import com.tigrisdata.db.annotation.TigrisPrimaryKey;
 import com.tigrisdata.db.client.error.TigrisException;
 import com.tigrisdata.db.type.TigrisCollectionType;
 import org.atteo.evo.inflector.English;
@@ -131,8 +132,12 @@ final class Utilities {
       for (String fieldName : generatedKeys[index].keySet()) {
         try {
           Field field = documents.get(index).getClass().getDeclaredField(fieldName);
-          field.setAccessible(true);
-          field.set(documents.get(index), generatedKeys[index].get(fieldName));
+          TigrisPrimaryKey tigrisPrimaryKey = field.getAnnotation(TigrisPrimaryKey.class);
+          // only mutate if the field is annotated to autoGenerate
+          if (tigrisPrimaryKey != null && tigrisPrimaryKey.autoGenerate()) {
+            field.setAccessible(true);
+            field.set(documents.get(index), generatedKeys[index].get(fieldName));
+          }
         } catch (NoSuchFieldException | IllegalAccessException ex) {
           throw new IllegalStateException(ex);
         }

--- a/client/src/test/java/com/tigrisdata/db/client/StandardTigrisAsyncCollectionTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/StandardTigrisAsyncCollectionTest.java
@@ -148,45 +148,40 @@ public class StandardTigrisAsyncCollectionTest {
       throws TigrisException, ExecutionException, InterruptedException {
     TigrisAsyncClient asyncClient = TestUtils.getTestAsyncClient(SERVER_NAME, grpcCleanup);
     TigrisAsyncDatabase db1 = asyncClient.getDatabase("autoGenerateTestDB");
+    AutoGeneratingPKeysModel input = new AutoGeneratingPKeysModel("name-without-id");
     CompletableFuture<InsertResponse<AutoGeneratingPKeysModel>> responseCompletableFuture =
-        db1.getCollection(AutoGeneratingPKeysModel.class)
-            .insert(Collections.singletonList(new AutoGeneratingPKeysModel("name-without-id")));
+        db1.getCollection(AutoGeneratingPKeysModel.class).insert(Collections.singletonList(input));
     InsertResponse<AutoGeneratingPKeysModel> response = responseCompletableFuture.get();
     Assert.assertNotNull(response);
-    Assert.assertEquals(5, response.getGeneratedKeys().length);
-    Assert.assertEquals(1, response.getGeneratedKeys()[0].get("intPKey"));
-    Assert.assertEquals(2, response.getGeneratedKeys()[1].get("intPKey"));
-    Assert.assertEquals(3, response.getGeneratedKeys()[2].get("intPKey"));
-    Assert.assertEquals(4, response.getGeneratedKeys()[3].get("intPKey"));
-    Assert.assertEquals(5, response.getGeneratedKeys()[4].get("intPKey"));
+    Assert.assertEquals(5, response.getKeys().length);
+    Assert.assertEquals(1, response.getKeys()[0].get("intPKey"));
+    Assert.assertEquals(2, response.getKeys()[1].get("intPKey"));
+    Assert.assertEquals(3, response.getKeys()[2].get("intPKey"));
+    Assert.assertEquals(4, response.getKeys()[3].get("intPKey"));
+    Assert.assertEquals(5, response.getKeys()[4].get("intPKey"));
 
-    Assert.assertEquals(Long.MAX_VALUE - 1, response.getGeneratedKeys()[0].get("longPKey"));
-    Assert.assertEquals(Long.MAX_VALUE - 2, response.getGeneratedKeys()[1].get("longPKey"));
-    Assert.assertEquals(Long.MAX_VALUE - 3, response.getGeneratedKeys()[2].get("longPKey"));
-    Assert.assertEquals(Long.MAX_VALUE - 4, response.getGeneratedKeys()[3].get("longPKey"));
-    Assert.assertEquals(Long.MAX_VALUE - 5, response.getGeneratedKeys()[4].get("longPKey"));
+    Assert.assertEquals(Long.MAX_VALUE - 1, response.getKeys()[0].get("longPKey"));
+    Assert.assertEquals(Long.MAX_VALUE - 2, response.getKeys()[1].get("longPKey"));
+    Assert.assertEquals(Long.MAX_VALUE - 3, response.getKeys()[2].get("longPKey"));
+    Assert.assertEquals(Long.MAX_VALUE - 4, response.getKeys()[3].get("longPKey"));
+    Assert.assertEquals(Long.MAX_VALUE - 5, response.getKeys()[4].get("longPKey"));
 
-    Assert.assertEquals("a", response.getGeneratedKeys()[0].get("strPKey"));
-    Assert.assertEquals("b", response.getGeneratedKeys()[1].get("strPKey"));
-    Assert.assertEquals("c", response.getGeneratedKeys()[2].get("strPKey"));
-    Assert.assertEquals("d", response.getGeneratedKeys()[3].get("strPKey"));
-    Assert.assertEquals("e", response.getGeneratedKeys()[4].get("strPKey"));
+    Assert.assertEquals("a", response.getKeys()[0].get("strPKey"));
+    Assert.assertEquals("b", response.getKeys()[1].get("strPKey"));
+    Assert.assertEquals("c", response.getKeys()[2].get("strPKey"));
+    Assert.assertEquals("d", response.getKeys()[3].get("strPKey"));
+    Assert.assertEquals("e", response.getKeys()[4].get("strPKey"));
 
-    Assert.assertNotNull(
-        UUID.fromString(response.getGeneratedKeys()[0].get("uuidPKey").toString()));
-    Assert.assertNotNull(
-        UUID.fromString(response.getGeneratedKeys()[1].get("uuidPKey").toString()));
-    Assert.assertNotNull(
-        UUID.fromString(response.getGeneratedKeys()[2].get("uuidPKey").toString()));
-    Assert.assertNotNull(
-        UUID.fromString(response.getGeneratedKeys()[3].get("uuidPKey").toString()));
-    Assert.assertNotNull(
-        UUID.fromString(response.getGeneratedKeys()[4].get("uuidPKey").toString()));
+    Assert.assertNotNull(UUID.fromString(response.getKeys()[0].get("uuidPKey").toString()));
+    Assert.assertNotNull(UUID.fromString(response.getKeys()[1].get("uuidPKey").toString()));
+    Assert.assertNotNull(UUID.fromString(response.getKeys()[2].get("uuidPKey").toString()));
+    Assert.assertNotNull(UUID.fromString(response.getKeys()[3].get("uuidPKey").toString()));
+    Assert.assertNotNull(UUID.fromString(response.getKeys()[4].get("uuidPKey").toString()));
 
-    Assert.assertEquals("a", response.getDocs().get(0).getStrPKey());
-    Assert.assertEquals(1, response.getDocs().get(0).getIntPKey());
-    Assert.assertEquals(9223372036854775806L, response.getDocs().get(0).getLongPKey());
-    Assert.assertNotNull(response.getDocs().get(0).getUuidPKey());
+    Assert.assertEquals("a", input.getStrPKey());
+    Assert.assertEquals(1, input.getIntPKey());
+    Assert.assertEquals(9223372036854775806L, input.getLongPKey());
+    Assert.assertNotNull(input.getUuidPKey());
   }
 
   @Test

--- a/client/src/test/java/com/tigrisdata/db/client/StandardTigrisCollectionTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/StandardTigrisCollectionTest.java
@@ -133,38 +133,35 @@ public class StandardTigrisCollectionTest {
   public void testInsertAutoGenerateKeys() throws TigrisException {
     TigrisClient client = TestUtils.getTestClient(SERVER_NAME, grpcCleanup);
     TigrisDatabase db1 = client.getDatabase("autoGenerateTestDB");
+    AutoGeneratingPKeysModel input = new AutoGeneratingPKeysModel("name-without-id");
     InsertResponse<AutoGeneratingPKeysModel> response =
-        db1.getCollection(AutoGeneratingPKeysModel.class)
-            .insert(
-                Collections.singletonList(new AutoGeneratingPKeysModel("name-without-id")),
-                new InsertRequestOptions());
+        db1.getCollection(AutoGeneratingPKeysModel.class).insert(input);
     Assert.assertNotNull(response);
-    Assert.assertEquals(5, response.getGeneratedKeys().length);
-    Assert.assertEquals(1, response.getGeneratedKeys()[0].get("intPKey"));
-    Assert.assertEquals(2, response.getGeneratedKeys()[1].get("intPKey"));
-    Assert.assertEquals(3, response.getGeneratedKeys()[2].get("intPKey"));
-    Assert.assertEquals(4, response.getGeneratedKeys()[3].get("intPKey"));
-    Assert.assertEquals(5, response.getGeneratedKeys()[4].get("intPKey"));
+    Assert.assertEquals(5, response.getKeys().length);
+    Assert.assertEquals(1, response.getKeys()[0].get("intPKey"));
+    Assert.assertEquals(2, response.getKeys()[1].get("intPKey"));
+    Assert.assertEquals(3, response.getKeys()[2].get("intPKey"));
+    Assert.assertEquals(4, response.getKeys()[3].get("intPKey"));
+    Assert.assertEquals(5, response.getKeys()[4].get("intPKey"));
 
-    Assert.assertEquals(Long.MAX_VALUE - 1, response.getGeneratedKeys()[0].get("longPKey"));
-    Assert.assertEquals(Long.MAX_VALUE - 2, response.getGeneratedKeys()[1].get("longPKey"));
-    Assert.assertEquals(Long.MAX_VALUE - 3, response.getGeneratedKeys()[2].get("longPKey"));
-    Assert.assertEquals(Long.MAX_VALUE - 4, response.getGeneratedKeys()[3].get("longPKey"));
-    Assert.assertEquals(Long.MAX_VALUE - 5, response.getGeneratedKeys()[4].get("longPKey"));
+    Assert.assertEquals(Long.MAX_VALUE - 1, response.getKeys()[0].get("longPKey"));
+    Assert.assertEquals(Long.MAX_VALUE - 2, response.getKeys()[1].get("longPKey"));
+    Assert.assertEquals(Long.MAX_VALUE - 3, response.getKeys()[2].get("longPKey"));
+    Assert.assertEquals(Long.MAX_VALUE - 4, response.getKeys()[3].get("longPKey"));
+    Assert.assertEquals(Long.MAX_VALUE - 5, response.getKeys()[4].get("longPKey"));
 
-    Assert.assertEquals("a", response.getGeneratedKeys()[0].get("strPKey"));
-    Assert.assertEquals("b", response.getGeneratedKeys()[1].get("strPKey"));
-    Assert.assertEquals("c", response.getGeneratedKeys()[2].get("strPKey"));
-    Assert.assertEquals("d", response.getGeneratedKeys()[3].get("strPKey"));
-    Assert.assertEquals("e", response.getGeneratedKeys()[4].get("strPKey"));
+    Assert.assertEquals("a", response.getKeys()[0].get("strPKey"));
+    Assert.assertEquals("b", response.getKeys()[1].get("strPKey"));
+    Assert.assertEquals("c", response.getKeys()[2].get("strPKey"));
+    Assert.assertEquals("d", response.getKeys()[3].get("strPKey"));
+    Assert.assertEquals("e", response.getKeys()[4].get("strPKey"));
 
-    Assert.assertNotNull(
-        UUID.fromString(response.getGeneratedKeys()[0].get("uuidPKey").toString()));
+    Assert.assertNotNull(UUID.fromString(response.getKeys()[0].get("uuidPKey").toString()));
 
-    Assert.assertEquals("a", response.getDocs().get(0).getStrPKey());
-    Assert.assertEquals(1, response.getDocs().get(0).getIntPKey());
-    Assert.assertEquals(9223372036854775806L, response.getDocs().get(0).getLongPKey());
-    Assert.assertNotNull(response.getDocs().get(0).getUuidPKey());
+    Assert.assertEquals("a", input.getStrPKey());
+    Assert.assertEquals(1, input.getIntPKey());
+    Assert.assertEquals(9223372036854775806L, input.getLongPKey());
+    Assert.assertNotNull(input.getUuidPKey());
   }
 
   @Test

--- a/client/src/test/java/com/tigrisdata/db/client/collection/AutoGeneratingPKeysModel.java
+++ b/client/src/test/java/com/tigrisdata/db/client/collection/AutoGeneratingPKeysModel.java
@@ -13,14 +13,22 @@
  */
 package com.tigrisdata.db.client.collection;
 
+import com.tigrisdata.db.annotation.TigrisPrimaryKey;
 import com.tigrisdata.db.type.TigrisCollectionType;
 
 import java.util.UUID;
 
 public class AutoGeneratingPKeysModel implements TigrisCollectionType {
+  @TigrisPrimaryKey(order = 1, autoGenerate = true)
   int intPKey;
+
+  @TigrisPrimaryKey(order = 2, autoGenerate = true)
   long longPKey;
+
+  @TigrisPrimaryKey(order = 3, autoGenerate = true)
   UUID uuidPKey;
+
+  @TigrisPrimaryKey(order = 4, autoGenerate = true)
   String strPKey;
 
   String name;


### PR DESCRIPTION
For insert and insertOrReplace operations, if the input model has primarykey fields set to autoGenerate, the input model will be mutated and set the values on successful insertion