### PR TITLE
style: Facet field options enum style fix

### DIFF
--- a/client/src/main/java/com/tigrisdata/db/client/AbstractTigrisCollection.java
+++ b/client/src/main/java/com/tigrisdata/db/client/AbstractTigrisCollection.java
@@ -106,8 +106,11 @@ abstract class AbstractTigrisCollection<T extends TigrisCollectionType> {
       Function<SearchResponse, SearchResult<T>> converter =
           r -> SearchResult.from(r, objectMapper, collectionTypeClass);
       return Utilities.transformIterator(resp, converter);
-    } catch (StatusRuntimeException ex) {
-      throw new TigrisException(SEARCH_FAILED, ex);
+    } catch (StatusRuntimeException statusRuntimeException) {
+      throw new TigrisException(
+          SEARCH_FAILED,
+          TypeConverter.extractTigrisError(statusRuntimeException),
+          statusRuntimeException);
     }
   }
 

--- a/client/src/main/java/com/tigrisdata/db/client/config/TigrisConfiguration.java
+++ b/client/src/main/java/com/tigrisdata/db/client/config/TigrisConfiguration.java
@@ -16,13 +16,15 @@ package com.tigrisdata.db.client.config;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import com.tigrisdata.db.jackson.TigrisAnnotationIntrospector;
-
 import java.time.Duration;
 
 /** Tigris client configuration */
 public class TigrisConfiguration {
+
   private final String serverURL;
   private final TigrisConfiguration.NetworkConfig network;
   private final ObjectMapper objectMapper;
@@ -68,7 +70,9 @@ public class TigrisConfiguration {
       // configure ObjectMapper to work with immutable objects
       this.objectMapper =
           new ObjectMapper()
-              .setAnnotationIntrospector(new TigrisAnnotationIntrospector())
+              .setAnnotationIntrospector(
+                  new AnnotationIntrospectorPair(
+                      new TigrisAnnotationIntrospector(), new JacksonAnnotationIntrospector()))
               .registerModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES))
               .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
@@ -103,6 +107,7 @@ public class TigrisConfiguration {
 
   /** Tigris network related configuration */
   public static class NetworkConfig {
+
     private final Duration deadline;
     private final boolean usePlainText;
 
@@ -125,6 +130,7 @@ public class TigrisConfiguration {
 
     /** Builder class for {@link NetworkConfig} */
     public static class Builder {
+
       public static final Duration DEFAULT_DEADLINE = Duration.ofSeconds(5);
 
       private Duration deadline;

--- a/client/src/main/java/com/tigrisdata/db/client/config/TigrisConfiguration.java
+++ b/client/src/main/java/com/tigrisdata/db/client/config/TigrisConfiguration.java
@@ -16,8 +16,6 @@ package com.tigrisdata.db.client.config;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.introspect.AnnotationIntrospectorPair;
-import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import com.tigrisdata.db.jackson.TigrisAnnotationIntrospector;
 import java.time.Duration;
@@ -70,9 +68,7 @@ public class TigrisConfiguration {
       // configure ObjectMapper to work with immutable objects
       this.objectMapper =
           new ObjectMapper()
-              .setAnnotationIntrospector(
-                  new AnnotationIntrospectorPair(
-                      new TigrisAnnotationIntrospector(), new JacksonAnnotationIntrospector()))
+              .setAnnotationIntrospector(new TigrisAnnotationIntrospector())
               .registerModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES))
               .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }

--- a/client/src/main/java/com/tigrisdata/db/client/search/FacetQueryOptions.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/FacetQueryOptions.java
@@ -14,6 +14,7 @@
 
 package com.tigrisdata.db.client.search;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tigrisdata.db.client.JSONSerializable;
@@ -21,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 enum FacetFieldType {
-  value("value");
+  VALUE("value");
   private final String strVal;
 
   FacetFieldType(String v) {
@@ -29,6 +30,7 @@ enum FacetFieldType {
   }
 
   @Override
+  @JsonValue
   public String toString() {
     return this.strVal;
   }
@@ -38,7 +40,7 @@ enum FacetFieldType {
 public final class FacetQueryOptions implements JSONSerializable {
 
   private static final long DEFAULT_LIMIT = 10;
-  private static final FacetFieldType DEFAULT_TYPE = FacetFieldType.value;
+  private static final FacetFieldType DEFAULT_TYPE = FacetFieldType.VALUE;
   private static final FacetQueryOptions DEFAULT_INSTANCE = newBuilder().build();
 
   private final FacetFieldType type;

--- a/client/src/main/java/com/tigrisdata/db/client/search/FacetQueryOptions.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/FacetQueryOptions.java
@@ -14,7 +14,6 @@
 
 package com.tigrisdata.db.client.search;
 
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tigrisdata.db.client.JSONSerializable;
@@ -30,7 +29,6 @@ enum FacetFieldType {
   }
 
   @Override
-  @JsonValue
   public String toString() {
     return this.strVal;
   }
@@ -39,20 +37,20 @@ enum FacetFieldType {
 /** Represents options related to Facet query for /search */
 public final class FacetQueryOptions implements JSONSerializable {
 
-  private static final long DEFAULT_LIMIT = 10;
+  private static final long DEFAULT_SIZE = 10;
   private static final FacetFieldType DEFAULT_TYPE = FacetFieldType.VALUE;
   private static final FacetQueryOptions DEFAULT_INSTANCE = newBuilder().build();
 
   private final FacetFieldType type;
-  private final long limit;
+  private final long size;
 
   private FacetQueryOptions(Builder builder) {
     this.type = builder.type;
-    this.limit = builder.limit;
+    this.size = builder.size;
   }
 
   /**
-   * Default options for a facet query type: value limit: 10
+   * Default options for a facet query type: value, size: 10
    *
    * @return {@link FacetQueryOptions}
    */
@@ -66,8 +64,8 @@ public final class FacetQueryOptions implements JSONSerializable {
   }
 
   /** Maximum number facet results to include in /search response */
-  public long getLimit() {
-    return limit;
+  public long getSize() {
+    return size;
   }
 
   @Override
@@ -76,7 +74,7 @@ public final class FacetQueryOptions implements JSONSerializable {
         new HashMap<String, String>() {
           {
             put("type", type.toString());
-            put("limit", String.valueOf(limit));
+            put("size", String.valueOf(size));
           }
         };
 
@@ -98,7 +96,7 @@ public final class FacetQueryOptions implements JSONSerializable {
 
     FacetQueryOptions that = (FacetQueryOptions) o;
 
-    if (limit != that.limit) {
+    if (size != that.size) {
       return false;
     }
     return type == that.type;
@@ -107,7 +105,7 @@ public final class FacetQueryOptions implements JSONSerializable {
   @Override
   public int hashCode() {
     int result = type != null ? type.hashCode() : 0;
-    result = 31 * result + (int) (limit ^ (limit >>> 32));
+    result = 31 * result + (int) (size ^ (size >>> 32));
     return result;
   }
 
@@ -119,11 +117,11 @@ public final class FacetQueryOptions implements JSONSerializable {
 
     private FacetFieldType type;
 
-    private long limit;
+    private long size;
 
     private Builder() {
       this.type = DEFAULT_TYPE;
-      this.limit = DEFAULT_LIMIT;
+      this.size = DEFAULT_SIZE;
     }
 
     /** Type of schema field */
@@ -133,8 +131,8 @@ public final class FacetQueryOptions implements JSONSerializable {
     }
 
     /** Maximum number facet results to include in /search response */
-    public Builder withLimit(long limit) {
-      this.limit = limit;
+    public Builder withSize(long size) {
+      this.size = size;
       return this;
     }
 

--- a/client/src/test/java/com/tigrisdata/db/client/StandardTigrisCollectionFailureTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/StandardTigrisCollectionFailureTest.java
@@ -19,13 +19,12 @@ import com.tigrisdata.db.client.grpc.FailingTestUserService;
 import io.grpc.Status;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.testing.GrpcCleanupRule;
+import java.util.Collections;
+import java.util.UUID;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-
-import java.util.Collections;
-import java.util.UUID;
 
 public class StandardTigrisCollectionFailureTest {
 

--- a/client/src/test/java/com/tigrisdata/db/client/grpc/FailingTestUserService.java
+++ b/client/src/test/java/com/tigrisdata/db/client/grpc/FailingTestUserService.java
@@ -113,6 +113,15 @@ public class FailingTestUserService extends TigrisGrpc.TigrisImplBase {
   }
 
   @Override
+  public void search(
+      Api.SearchRequest request, StreamObserver<Api.SearchResponse> responseObserver) {
+    responseObserver.onError(
+        Status.FAILED_PRECONDITION
+            .withDescription("Test failure " + request.getDb())
+            .asRuntimeException());
+  }
+
+  @Override
   public void createOrUpdateCollection(
       Api.CreateOrUpdateCollectionRequest request,
       StreamObserver<Api.CreateOrUpdateCollectionResponse> responseObserver) {

--- a/client/src/test/java/com/tigrisdata/db/client/search/FacetFieldsQueryTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/FacetFieldsQueryTest.java
@@ -43,7 +43,7 @@ public class FacetFieldsQueryTest {
   @Test
   public void buildWithFields() {
     Map<String, FacetQueryOptions> optionsMap =
-        Collections.singletonMap("someField", FacetQueryOptions.newBuilder().withLimit(30).build());
+        Collections.singletonMap("someField", FacetQueryOptions.newBuilder().withSize(30).build());
     FacetFieldsQuery fields = FacetFieldsQuery.newBuilder().addAll(optionsMap).build();
     Assert.assertEquals(optionsMap, fields.getFacetFields());
   }
@@ -52,7 +52,7 @@ public class FacetFieldsQueryTest {
   public void buildWithOptions() {
     FacetFieldsQuery query =
         FacetFieldsQuery.newBuilder()
-            .withFieldOptions("name", FacetQueryOptions.newBuilder().withLimit(20).build())
+            .withFieldOptions("name", FacetQueryOptions.newBuilder().withSize(20).build())
             .build();
     Assert.assertTrue(query.getFacetFields().containsKey("name"));
   }
@@ -60,9 +60,9 @@ public class FacetFieldsQueryTest {
   @Test
   public void toJSONSerialization() {
     Map<String, FacetQueryOptions> optionsMap =
-        Collections.singletonMap("someField", FacetQueryOptions.newBuilder().withLimit(30).build());
+        Collections.singletonMap("someField", FacetQueryOptions.newBuilder().withSize(30).build());
     FacetFieldsQuery input = FacetFieldsQuery.newBuilder().addAll(optionsMap).build();
-    String expected = "{\"someField\":{\"type\":\"value\",\"limit\":30}}";
+    String expected = "{\"someField\":{\"size\":\"30\",\"type\":\"value\"}}";
     Assert.assertEquals(expected, input.toJSON(DEFAULT_OBJECT_MAPPER));
   }
 

--- a/client/src/test/java/com/tigrisdata/db/client/search/FacetQueryOptionsTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/FacetQueryOptionsTest.java
@@ -30,7 +30,7 @@ public class FacetQueryOptionsTest {
   @Test
   public void defaultInstance() {
     FacetQueryOptions expected =
-        FacetQueryOptions.newBuilder().withType(FacetFieldType.value).withLimit(10).build();
+        FacetQueryOptions.newBuilder().withType(FacetFieldType.VALUE).withLimit(10).build();
     FacetQueryOptions actual = FacetQueryOptions.getDefaultInstance();
     Assert.assertEquals(expected, actual);
   }
@@ -38,7 +38,7 @@ public class FacetQueryOptionsTest {
   @Test
   public void withNullType() {
     FacetQueryOptions actual = FacetQueryOptions.newBuilder().withType(null).withLimit(20).build();
-    Assert.assertEquals(FacetFieldType.value, actual.getType());
+    Assert.assertEquals(FacetFieldType.VALUE, actual.getType());
     Assert.assertEquals(20, actual.getLimit());
   }
 

--- a/client/src/test/java/com/tigrisdata/db/client/search/FacetQueryOptionsTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/FacetQueryOptionsTest.java
@@ -30,16 +30,16 @@ public class FacetQueryOptionsTest {
   @Test
   public void defaultInstance() {
     FacetQueryOptions expected =
-        FacetQueryOptions.newBuilder().withType(FacetFieldType.VALUE).withLimit(10).build();
+        FacetQueryOptions.newBuilder().withType(FacetFieldType.VALUE).withSize(10).build();
     FacetQueryOptions actual = FacetQueryOptions.getDefaultInstance();
     Assert.assertEquals(expected, actual);
   }
 
   @Test
   public void withNullType() {
-    FacetQueryOptions actual = FacetQueryOptions.newBuilder().withType(null).withLimit(20).build();
+    FacetQueryOptions actual = FacetQueryOptions.newBuilder().withType(null).withSize(20).build();
     Assert.assertEquals(FacetFieldType.VALUE, actual.getType());
-    Assert.assertEquals(20, actual.getLimit());
+    Assert.assertEquals(20, actual.getSize());
   }
 
   @Test
@@ -49,8 +49,8 @@ public class FacetQueryOptionsTest {
 
   @Test
   public void toJSONSerialization() {
-    FacetQueryOptions options = FacetQueryOptions.newBuilder().withLimit(20).build();
-    String expected = "{\"limit\":\"20\",\"type\":\"value\"}";
+    FacetQueryOptions options = FacetQueryOptions.newBuilder().withSize(20).build();
+    String expected = "{\"size\":\"20\",\"type\":\"value\"}";
     String actual = options.toJSON(DEFAULT_OBJECT_MAPPER);
     Assert.assertEquals(expected, actual);
   }


### PR DESCRIPTION
- Updated enum to be all caps
- Extracted error out of tigris exception
- Renamed `FacetFieldQueryOptions.limit` to `FacetFieldQueryOptions.size`