### PR TITLE
feat: Async search client

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,13 @@ users.delete(
         Filters.eq("id", 2)
     )
 );
+
+// search - search for users with name "Jania"
+users.search(
+    SearchRequest.newBuilder("Jania")
+      .withSearchFields("name")
+      .build()
+    );
 ```
 
 # License

--- a/client/src/main/java/com/tigrisdata/db/client/StandardTigrisAsyncCollection.java
+++ b/client/src/main/java/com/tigrisdata/db/client/StandardTigrisAsyncCollection.java
@@ -128,8 +128,7 @@ class StandardTigrisAsyncCollection<T extends TigrisCollectionType>
         toSearchRequest(databaseName, collectionName, request, objectMapper);
     stub.search(
         searchRequest,
-        new SearchResponseObserverAdapter<>(
-            reader, collectionTypeClass, objectMapper, SEARCH_FAILED));
+        new SearchResponseObserverAdapter<>(reader, collectionTypeClass, objectMapper));
   }
 
   @Override
@@ -483,17 +482,14 @@ class StandardTigrisAsyncCollection<T extends TigrisCollectionType>
     private final TigrisAsyncSearchReader<T> reader;
     private final Class<T> collectionTypeClass;
     private final ObjectMapper objectMapper;
-    private final String errorMessage;
 
     public SearchResponseObserverAdapter(
         TigrisAsyncSearchReader<T> reader,
         Class<T> collectionTypeClass,
-        ObjectMapper objectMapper,
-        String errorMessage) {
+        ObjectMapper objectMapper) {
       this.reader = reader;
       this.collectionTypeClass = collectionTypeClass;
       this.objectMapper = objectMapper;
-      this.errorMessage = errorMessage;
     }
 
     @Override
@@ -507,9 +503,9 @@ class StandardTigrisAsyncCollection<T extends TigrisCollectionType>
       if (throwable instanceof StatusRuntimeException) {
         reader.onError(
             new TigrisException(
-                errorMessage, extractTigrisError((StatusRuntimeException) throwable), throwable));
+                SEARCH_FAILED, extractTigrisError((StatusRuntimeException) throwable), throwable));
       } else {
-        reader.onError(new TigrisException(errorMessage, throwable));
+        reader.onError(new TigrisException(SEARCH_FAILED, throwable));
       }
     }
 

--- a/client/src/main/java/com/tigrisdata/db/client/TigrisAsyncCallback.java
+++ b/client/src/main/java/com/tigrisdata/db/client/TigrisAsyncCallback.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client;
+
+/**
+ * Asynchronous callback to receive messages from server
+ *
+ * @param <T> type of message
+ */
+public interface TigrisAsyncCallback<T> {
+
+  /**
+   * Receives a message from the stream.
+   *
+   * <p>Can be called many times but is never called after {@link #onError(Throwable)} or {@link
+   * #onCompleted()} are called.
+   *
+   * <p>If an exception is thrown by an implementation the caller is expected to terminate the
+   * stream by calling {@link #onError(Throwable)} with the caught exception prior to propagating
+   * it.
+   *
+   * @param message the value passed from the server
+   */
+  void onNext(T message);
+
+  /**
+   * Receives terminating error from the stream.
+   *
+   * @param t captures the error
+   */
+  void onError(Throwable t);
+
+  /**
+   * Receives a notification of successful stream completion.
+   *
+   * <p>May only be called once and if called it must be the last method called. In particular if an
+   * exception is thrown by an implementation of {@code onCompleted} no further calls to any method
+   * are allowed.
+   */
+  void onCompleted();
+}

--- a/client/src/main/java/com/tigrisdata/db/client/TigrisAsyncCollection.java
+++ b/client/src/main/java/com/tigrisdata/db/client/TigrisAsyncCollection.java
@@ -14,8 +14,9 @@
 package com.tigrisdata.db.client;
 
 import com.tigrisdata.db.client.error.TigrisException;
+import com.tigrisdata.db.client.search.SearchRequest;
+import com.tigrisdata.db.client.search.SearchRequestOptions;
 import com.tigrisdata.db.type.TigrisCollectionType;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -65,6 +66,32 @@ public interface TigrisAsyncCollection<T extends TigrisCollectionType>
    * @return a future to the document
    */
   CompletableFuture<Optional<T>> readOne(TigrisFilter filter);
+
+  /**
+   * Search for documents in a collection. Easily perform sophisticated queries and refine results
+   * using filters with advanced features like faceting and ordering.
+   *
+   * <p>Note: Searching is expensive. If using as a primary key based lookup, use {@code read()}
+   * instead
+   *
+   * @param request search request to execute
+   * @param options search pagination options
+   * @param reader reader callback
+   * @see #search(SearchRequest, TigrisAsyncSearchReader)
+   */
+  void search(
+      SearchRequest request, SearchRequestOptions options, TigrisAsyncSearchReader<T> reader);
+
+  /**
+   * Search for documents in a collection.
+   *
+   * <p>Wrapper around {@link #search(SearchRequest, SearchRequestOptions, TigrisAsyncSearchReader)}
+   * with default pagination options
+   *
+   * @param request search request to execute
+   * @param reader reader callback
+   */
+  void search(SearchRequest request, TigrisAsyncSearchReader<T> reader);
 
   /**
    * Inserts documents into collection

--- a/client/src/main/java/com/tigrisdata/db/client/TigrisAsyncReader.java
+++ b/client/src/main/java/com/tigrisdata/db/client/TigrisAsyncReader.java
@@ -16,18 +16,8 @@ package com.tigrisdata.db.client;
 import com.tigrisdata.db.type.TigrisCollectionType;
 
 /**
- * A callback that reads the documents
+ * Asynchronous callback to receive collection documents from server
  *
  * @param <T> Collection type
  */
-public interface TigrisAsyncReader<T extends TigrisCollectionType> {
-
-  /** @param document next document */
-  void onNext(T document);
-
-  /** @param t captures the error */
-  void onError(Throwable t);
-
-  /** Gets invoked when read is completed */
-  void onCompleted();
-}
+public interface TigrisAsyncReader<T extends TigrisCollectionType> extends TigrisAsyncCallback<T> {}

--- a/client/src/main/java/com/tigrisdata/db/client/TigrisAsyncSearchReader.java
+++ b/client/src/main/java/com/tigrisdata/db/client/TigrisAsyncSearchReader.java
@@ -11,7 +11,16 @@
  * express or implied. See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.tigrisdata.db.client;
 
-/** Asynchronous callback to receive events */
-public interface TigrisAsyncStreamer extends TigrisAsyncCallback<StreamEvent> {}
+import com.tigrisdata.db.client.search.SearchResult;
+import com.tigrisdata.db.type.TigrisCollectionType;
+
+/**
+ * Asynchronous callback to receive {@link SearchResult} from server
+ *
+ * @param <T> Collection type
+ */
+public interface TigrisAsyncSearchReader<T extends TigrisCollectionType>
+    extends TigrisAsyncCallback<SearchResult<T>> {}

--- a/client/src/main/java/com/tigrisdata/db/client/TigrisCollection.java
+++ b/client/src/main/java/com/tigrisdata/db/client/TigrisCollection.java
@@ -89,6 +89,7 @@ public interface TigrisCollection<T extends TigrisCollectionType>
    * @param options search pagination options
    * @return stream of search results
    * @throws TigrisException in case of error
+   * @see #search(SearchRequest)
    */
   Iterator<SearchResult<T>> search(SearchRequest request, SearchRequestOptions options)
       throws TigrisException;

--- a/client/src/main/java/com/tigrisdata/db/client/search/FacetFieldsQuery.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/FacetFieldsQuery.java
@@ -16,6 +16,7 @@ package com.tigrisdata.db.client.search;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,7 +37,7 @@ public final class FacetFieldsQuery implements FacetQuery {
   }
 
   /**
-   * Represents empty facet query, server will not return any facet results
+   * Represents empty facet query, server will not return any facets
    *
    * @return an empty {@link FacetFieldsQuery}
    */
@@ -119,7 +120,7 @@ public final class FacetFieldsQuery implements FacetQuery {
     private Builder() {}
 
     /**
-     * Sets a collection field name to include facet results in search response
+     * Sets a collection field name to include facets in search results
      *
      * <p>Uses default {@link FacetQueryOptions} options
      *
@@ -131,6 +132,22 @@ public final class FacetFieldsQuery implements FacetQuery {
         fieldMap = new HashMap<>();
       }
       fieldMap.put(field, FacetQueryOptions.getDefault());
+      return this;
+    }
+
+    /**
+     * Sets collection field names to include in facets in search results
+     *
+     * <p>Uses default {@link FacetQueryOptions} options
+     *
+     * @param fields list of field names
+     * @return {@link FacetFieldsQuery.Builder}
+     */
+    public Builder withFields(Collection<? extends String> fields) {
+      if (fieldMap == null) {
+        fieldMap = new HashMap<>();
+      }
+      fields.forEach(f -> fieldMap.put(f, FacetQueryOptions.getDefault()));
       return this;
     }
 

--- a/client/src/main/java/com/tigrisdata/db/client/search/FacetFieldsQuery.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/FacetFieldsQuery.java
@@ -143,7 +143,7 @@ public final class FacetFieldsQuery implements FacetQuery {
      * @param fields list of field names
      * @return {@link FacetFieldsQuery.Builder}
      */
-    public Builder withFields(Collection<? extends String> fields) {
+    public Builder withFields(Collection<String> fields) {
       if (fieldMap == null) {
         fieldMap = new HashMap<>();
       }

--- a/client/src/main/java/com/tigrisdata/db/client/search/QueryString.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/QueryString.java
@@ -94,11 +94,13 @@ public final class QueryString implements Query {
      * Constructs a {@link QueryString}
      *
      * @return {@link QueryString}
-     * @throws NullPointerException if query string is null
+     * @throws IllegalArgumentException if query string is null
      * @see #getMatchAllQuery()
      */
     public QueryString build() {
-      Objects.requireNonNull(this.q);
+      if (this.q == null) {
+        throw new IllegalArgumentException("Query cannot be null");
+      }
       return new QueryString(this.q);
     }
   }

--- a/client/src/main/java/com/tigrisdata/db/client/search/SearchFields.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SearchFields.java
@@ -116,7 +116,7 @@ public final class SearchFields implements JSONSerializable {
      * @param fields list of schema field names as string
      * @return {@link SearchFields.Builder}
      */
-    public Builder withFields(Collection<? extends String> fields) {
+    public Builder withFields(Collection<String> fields) {
       if (this.fields == null) {
         this.fields = new ArrayList<>();
       }

--- a/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
@@ -16,6 +16,7 @@ package com.tigrisdata.db.client.search;
 
 import com.tigrisdata.db.client.ReadFields;
 import com.tigrisdata.db.client.TigrisFilter;
+import java.util.Arrays;
 import java.util.Objects;
 
 /** Builder class to create a Search request */
@@ -94,7 +95,17 @@ public final class SearchRequest {
   /**
    * Builder API for {@link SearchRequest}
    *
-   * @param query - Search query object
+   * @param queryString Search query string
+   * @return {@link SearchRequest.Builder} object
+   */
+  public static Builder newBuilder(String queryString) {
+    return new Builder(queryString);
+  }
+
+  /**
+   * Builder API for {@link SearchRequest}
+   *
+   * @param query Search query object
    * @return {@link SearchRequest.Builder} object
    */
   public static Builder newBuilder(Query query) {
@@ -110,8 +121,24 @@ public final class SearchRequest {
     private SortOrder sortOrder;
     private ReadFields fields;
 
+    private Builder(String queryString) {
+      this.query = QueryString.newBuilder(queryString).build();
+    }
+
     private Builder(Query query) {
       this.query = query;
+    }
+
+    /**
+     * Optional - Sets the search fields to project search query on
+     *
+     * @param fields Collection field names
+     * @return {@link SearchRequest.Builder}
+     * @see #withSearchFields(SearchFields)
+     */
+    public Builder withSearchFields(String... fields) {
+      this.searchFields = SearchFields.newBuilder().withFields(Arrays.asList(fields)).build();
+      return this;
     }
 
     /**
@@ -124,6 +151,7 @@ public final class SearchRequest {
       this.searchFields = fields;
       return this;
     }
+
     /**
      * Optional - Sets the filter to further refine search results
      *
@@ -134,6 +162,19 @@ public final class SearchRequest {
       this.filter = filter;
       return this;
     }
+
+    /**
+     * Optional - Sets the facet fields to categorically arrange indexed terms
+     *
+     * @param fields {@link }
+     * @return {@link SearchRequest.Builder}
+     * @see #withFacetQuery(FacetQuery)
+     */
+    public Builder withFacetFields(String... fields) {
+      this.facetQuery = FacetFieldsQuery.newBuilder().withFields(Arrays.asList(fields)).build();
+      return this;
+    }
+
     /**
      * Optional - Sets the facet query to categorically arrange the indexed terms
      *
@@ -144,6 +185,7 @@ public final class SearchRequest {
       this.facetQuery = facetQuery;
       return this;
     }
+
     /**
      * Optional - Sets the SortOrder to sorts search results according to specified attributes and
      * indicated order

--- a/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
@@ -17,7 +17,6 @@ package com.tigrisdata.db.client.search;
 import com.tigrisdata.db.client.ReadFields;
 import com.tigrisdata.db.client.TigrisFilter;
 import java.util.Arrays;
-import java.util.Objects;
 
 /** Builder class to create a Search request */
 public final class SearchRequest {
@@ -212,11 +211,13 @@ public final class SearchRequest {
     /**
      * Constructs a {@link SearchRequest}
      *
-     * @throws NullPointerException if query is null
+     * @throws IllegalArgumentException if query is null
      * @return {@link SearchRequest}
      */
     public SearchRequest build() {
-      Objects.requireNonNull(this.query);
+      if (this.query == null) {
+        throw new IllegalArgumentException("Query cannot be null");
+      }
       return new SearchRequest(this);
     }
   }

--- a/client/src/main/java/com/tigrisdata/db/client/search/package-info.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/package-info.java
@@ -1,2 +1,16 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /** Provides search API related classes */
 package com.tigrisdata.db.client.search;

--- a/client/src/test/java/com/tigrisdata/db/client/StandardTigrisAsyncCollectionFailureTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/StandardTigrisAsyncCollectionFailureTest.java
@@ -16,19 +16,20 @@ package com.tigrisdata.db.client;
 import com.tigrisdata.db.client.collection.DB1_C1;
 import com.tigrisdata.db.client.error.TigrisException;
 import com.tigrisdata.db.client.grpc.FailingTestUserService;
+import com.tigrisdata.db.client.search.SearchRequest;
+import com.tigrisdata.db.client.search.SearchResult;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.testing.GrpcCleanupRule;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
 
 public class StandardTigrisAsyncCollectionFailureTest {
 
@@ -52,6 +53,12 @@ public class StandardTigrisAsyncCollectionFailureTest {
   public void testRead() {
     TigrisAsyncClient asyncClient = TestUtils.getTestAsyncClient(SERVER_NAME, grpcCleanup);
     readAndExpectError(asyncClient.getDatabase("db1"));
+  }
+
+  @Test
+  public void testSearch() {
+    TigrisAsyncClient asyncClient = TestUtils.getTestAsyncClient(SERVER_NAME, grpcCleanup);
+    searchAndExpectError(asyncClient.getDatabase("db1"));
   }
 
   @Test
@@ -126,6 +133,42 @@ public class StandardTigrisAsyncCollectionFailureTest {
             new TigrisAsyncReader<DB1_C1>() {
               @Override
               public void onNext(DB1_C1 document) {
+                Assert.fail("This must fail");
+              }
+
+              @Override
+              public void onError(Throwable t) {
+                errorCount.incrementAndGet();
+              }
+
+              @Override
+              public void onCompleted() {
+                completed.set(true);
+              }
+            });
+    int timeout = 0;
+    while (!completed.get() && timeout < 20) {
+      timeout++;
+      try {
+        //noinspection BusyWait
+        Thread.sleep(100);
+      } catch (InterruptedException ignore) {
+      }
+    }
+
+    // there must not be any errors
+    Assert.assertEquals(1, errorCount.get());
+  }
+
+  private static void searchAndExpectError(TigrisAsyncDatabase db1) {
+    AtomicInteger errorCount = new AtomicInteger();
+    AtomicBoolean completed = new AtomicBoolean(false);
+    db1.getCollection(DB1_C1.class)
+        .search(
+            SearchRequest.newBuilder("").build(),
+            new TigrisAsyncSearchReader<DB1_C1>() {
+              @Override
+              public void onNext(SearchResult<DB1_C1> result) {
                 Assert.fail("This must fail");
               }
 

--- a/client/src/test/java/com/tigrisdata/db/client/StandardTigrisAsyncCollectionFailureTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/StandardTigrisAsyncCollectionFailureTest.java
@@ -192,7 +192,6 @@ public class StandardTigrisAsyncCollectionFailureTest {
       }
     }
 
-    // there must not be any errors
     Assert.assertEquals(1, errorCount.get());
   }
 }

--- a/client/src/test/java/com/tigrisdata/db/client/collection/User.java
+++ b/client/src/test/java/com/tigrisdata/db/client/collection/User.java
@@ -17,13 +17,16 @@ import com.tigrisdata.db.type.TigrisCollectionType;
 
 /** Test collection model */
 public class User implements TigrisCollectionType {
-  String name;
   int id;
+  String name;
+  double salary;
 
   public User() {}
 
-  public User(String name) {
+  public User(int id, String name, double salary) {
+    this.id = id;
     this.name = name;
+    this.salary = salary;
   }
 
   public String getName() {
@@ -40,5 +43,13 @@ public class User implements TigrisCollectionType {
 
   public void setId(int id) {
     this.id = id;
+  }
+
+  public double getSalary() {
+    return salary;
+  }
+
+  public void setSalary(double salary) {
+    this.salary = salary;
   }
 }

--- a/client/src/test/java/com/tigrisdata/db/client/search/FacetFieldsQueryTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/FacetFieldsQueryTest.java
@@ -18,7 +18,9 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tigrisdata.db.client.config.TigrisConfiguration;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.Assert;
@@ -41,11 +43,18 @@ public class FacetFieldsQueryTest {
   }
 
   @Test
-  public void buildWithFields() {
+  public void buildWithFieldOptions() {
     Map<String, FacetQueryOptions> optionsMap =
         Collections.singletonMap("someField", FacetQueryOptions.newBuilder().withSize(30).build());
     FacetFieldsQuery fields = FacetFieldsQuery.newBuilder().addAll(optionsMap).build();
     Assert.assertEquals(optionsMap, fields.getFacetFields());
+  }
+
+  @Test
+  public void buildWithFields() {
+    List<String> expected = Arrays.asList("field1", "field2", "field3");
+    FacetFieldsQuery fields = FacetFieldsQuery.newBuilder().withFields(expected).build();
+    expected.forEach(e -> Assert.assertTrue(fields.getFacetFields().containsKey(e)));
   }
 
   @Test

--- a/client/src/test/java/com/tigrisdata/db/client/search/QueryStringTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/QueryStringTest.java
@@ -37,7 +37,10 @@ public class QueryStringTest {
 
   @Test
   public void buildWithNull() {
-    Assert.assertThrows(NullPointerException.class, () -> QueryString.newBuilder(null).build());
+    Exception thrown =
+        Assert.assertThrows(
+            IllegalArgumentException.class, () -> QueryString.newBuilder(null).build());
+    Assert.assertEquals("Query cannot be null", thrown.getMessage());
   }
 
   @Test

--- a/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
@@ -53,7 +53,6 @@ public class SearchRequestTest {
     Query expectedQuery = QueryString.newBuilder("some query").build();
     SearchFields expectedSearchFields = SearchFields.newBuilder().withField("field_1").build();
     FacetQuery expectedFacetQuery = FacetFieldsQuery.newBuilder().withField("field_3").build();
-
     SearchRequest actual =
         SearchRequest.newBuilder("some query")
             .withSearchFields("field_1")

--- a/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
@@ -65,7 +65,9 @@ public class SearchRequestTest {
 
   @Test
   public void failsWithNullQuery() {
-    Assert.assertThrows(
-        NullPointerException.class, () -> SearchRequest.newBuilder((String) null).build());
+    Exception thrown =
+        Assert.assertThrows(
+            IllegalArgumentException.class, () -> SearchRequest.newBuilder((String) null).build());
+    Assert.assertEquals("Query cannot be null", thrown.getMessage());
   }
 }

--- a/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
@@ -49,7 +49,24 @@ public class SearchRequestTest {
   }
 
   @Test
+  public void buildWithVarargs() {
+    Query expectedQuery = QueryString.newBuilder("some query").build();
+    SearchFields expectedSearchFields = SearchFields.newBuilder().withField("field_1").build();
+    FacetQuery expectedFacetQuery = FacetFieldsQuery.newBuilder().withField("field_3").build();
+
+    SearchRequest actual =
+        SearchRequest.newBuilder("some query")
+            .withSearchFields("field_1")
+            .withFacetFields("field_3")
+            .build();
+    Assert.assertEquals(expectedQuery, actual.getQuery());
+    Assert.assertEquals(expectedSearchFields, actual.getSearchFields());
+    Assert.assertEquals(expectedFacetQuery, actual.getFacetQuery());
+  }
+
+  @Test
   public void failsWithNullQuery() {
-    Assert.assertThrows(NullPointerException.class, () -> SearchRequest.newBuilder(null).build());
+    Assert.assertThrows(
+        NullPointerException.class, () -> SearchRequest.newBuilder((String) null).build());
   }
 }


### PR DESCRIPTION
- User friendly search request builder. Introduced following capabilities:
```java
SearchRequest.newBuilder("my search").build();
SearchRequest.newBuilder("my search").withSearchFields("first_name", "last_name").build();
SearchRequest.newBuilder("my search").withFacetFields("first_name", "last_name").build();
```

- Updated readme docs
- Async search client

### Checks
- [x] Unit tests
- [x] Javadocs publishing passes without error
- [x] Coverage for new features