### PR TITLE
refactor: Explicitly specify the search query

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Tigris provides an easy-to-use and intuitive interface for Java combined with da
 The Tigris Java client libraries offer both asynchronous and synchronous clients.
 
 # Documentation
-- [Quickstart](https://docs.tigrisdata.com/quickstart/with-java)
-- [Java Sync Client](https://docs.tigrisdata.com/client-libraries/java/sync-client)
-- [Java Async Client](https://docs.tigrisdata.com/client-libraries/java/async-client)
-- [Data Modeling Using Java](https://docs.tigrisdata.com/datamodels/using-java)
+- [Quickstart](https://docs.tigrisdata.com/quickstart)
+- [Java Sync Client](https://docs.tigrisdata.com/java/sync-client)
+- [Java Async Client](https://docs.tigrisdata.com/java/async-client)
+- [Data Modeling Using Java](https://docs.tigrisdata.com/java/datamodel/overview)
 
 # Maven Configuration
 
@@ -78,7 +78,8 @@ users.delete(
 
 // search - search for users with name "Jania"
 users.search(
-    SearchRequest.newBuilder("Jania")
+    SearchRequest.newBuilder()
+      .withQuery("Jania")
       .withSearchFields("name")
       .build()
     );

--- a/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
@@ -94,38 +94,34 @@ public final class SearchRequest {
   /**
    * Builder API for {@link SearchRequest}
    *
-   * @param queryString Search query string
    * @return {@link SearchRequest.Builder} object
    */
-  public static Builder newBuilder(String queryString) {
-    return new Builder(queryString);
-  }
-
-  /**
-   * Builder API for {@link SearchRequest}
-   *
-   * @param query Search query object
-   * @return {@link SearchRequest.Builder} object
-   */
-  public static Builder newBuilder(Query query) {
-    return new Builder(query);
+  public static Builder newBuilder() {
+    return new Builder();
   }
 
   public static final class Builder {
 
-    private final Query query;
+    private Query query;
     private TigrisFilter filter;
     private SearchFields searchFields;
     private FacetQuery facetQuery;
     private SortOrder sortOrder;
     private ReadFields fields;
 
-    private Builder(String queryString) {
-      this.query = QueryString.newBuilder(queryString).build();
+    private Builder() {
+      this.query = QueryString.getMatchAllQuery();
     }
 
-    private Builder(Query query) {
-      this.query = query;
+    /**
+     * Optional - Sets the query text. Defaults to {@code QueryString.getMatchAllQuery()}
+     *
+     * @param q the query term
+     * @return {@link SearchRequest.Builder}
+     */
+    public Builder withQuery(String q) {
+      this.query = QueryString.newBuilder(q).build();
+      return this;
     }
 
     /**

--- a/client/src/test/java/com/tigrisdata/db/client/StandardTigrisAsyncCollectionFailureTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/StandardTigrisAsyncCollectionFailureTest.java
@@ -165,7 +165,7 @@ public class StandardTigrisAsyncCollectionFailureTest {
     AtomicBoolean completed = new AtomicBoolean(false);
     db1.getCollection(DB1_C1.class)
         .search(
-            SearchRequest.newBuilder("").build(),
+            SearchRequest.newBuilder().build(),
             new TigrisAsyncSearchReader<DB1_C1>() {
               @Override
               public void onNext(SearchResult<DB1_C1> result) {

--- a/client/src/test/java/com/tigrisdata/db/client/StandardTigrisAsyncCollectionTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/StandardTigrisAsyncCollectionTest.java
@@ -460,7 +460,7 @@ public class StandardTigrisAsyncCollectionTest {
 
     db1.getCollection(DB1_C1.class)
         .search(
-            SearchRequest.newBuilder("name").build(),
+            SearchRequest.newBuilder().build(),
             new TigrisAsyncSearchReader<DB1_C1>() {
               @Override
               public void onNext(SearchResult<DB1_C1> result) {

--- a/client/src/test/java/com/tigrisdata/db/client/StandardTigrisCollectionTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/StandardTigrisCollectionTest.java
@@ -20,17 +20,10 @@ import com.tigrisdata.db.client.error.TigrisException;
 import com.tigrisdata.db.client.grpc.TestUserService;
 import com.tigrisdata.db.client.search.FacetCountDistribution;
 import com.tigrisdata.db.client.search.FacetFieldsQuery;
-import com.tigrisdata.db.client.search.QueryString;
 import com.tigrisdata.db.client.search.SearchRequest;
 import com.tigrisdata.db.client.search.SearchResult;
 import io.grpc.inprocess.InProcessServerBuilder;
 import io.grpc.testing.GrpcCleanupRule;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,6 +31,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
 
 public class StandardTigrisCollectionTest {
 
@@ -134,7 +132,8 @@ public class StandardTigrisCollectionTest {
     TigrisDatabase db1 = client.getDatabase("db1");
     TigrisCollection<DB1_C1> collection = db1.getCollection(DB1_C1.class);
     SearchRequest searchRequest =
-        SearchRequest.newBuilder(QueryString.newBuilder("my search string").build())
+        SearchRequest.newBuilder()
+            .withQuery("my search string")
             .withFacetQuery(FacetFieldsQuery.newBuilder().withField("name").build())
             .withReadFields(ReadFields.newBuilder().includeField("other_field").build())
             .withFilter(

--- a/client/src/test/java/com/tigrisdata/db/client/TypeConverterTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/TypeConverterTest.java
@@ -23,7 +23,6 @@ import com.tigrisdata.db.api.v1.grpc.Api;
 import com.tigrisdata.db.client.config.TigrisConfiguration;
 import com.tigrisdata.db.client.error.TigrisError;
 import com.tigrisdata.db.client.error.TigrisException;
-import com.tigrisdata.db.client.search.QueryString;
 import com.tigrisdata.db.client.search.SearchRequest;
 import com.tigrisdata.db.client.search.SearchRequestOptions;
 import io.grpc.StatusRuntimeException;
@@ -83,8 +82,7 @@ public class TypeConverterTest {
 
   @Test
   public void toSearchRequest() {
-    SearchRequest input =
-        SearchRequest.newBuilder(QueryString.newBuilder("search str").build()).build();
+    SearchRequest input = SearchRequest.newBuilder().withQuery("search str").build();
     SearchRequestOptions options =
         SearchRequestOptions.newBuilder().withPage(8).withPerPage(30).build();
     Api.SearchRequest apiSearchRequest =

--- a/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
@@ -25,14 +25,15 @@ public class SearchRequestTest {
   // TODO: Add sort orders to this test
   @Test
   public void build() {
-    Query expectedQuery = QueryString.getMatchAllQuery();
+    QueryString expectedQuery = QueryString.getMatchAllQuery();
     SearchFields expectedSearchFields = SearchFields.newBuilder().withField("field_1").build();
     TigrisFilter expectedFilter = Filters.eq("field_2", "otherValue");
     FacetQuery expectedFacetQuery = FacetFieldsQuery.newBuilder().withField("field_3").build();
     ReadFields expectedReadFields = ReadFields.newBuilder().includeField("field_1").build();
 
     SearchRequest actual =
-        SearchRequest.newBuilder(expectedQuery)
+        SearchRequest.newBuilder()
+            .withQuery(expectedQuery.getQ())
             .withSearchFields(expectedSearchFields)
             .withFacetQuery(expectedFacetQuery)
             .withFilter(expectedFilter)
@@ -54,7 +55,8 @@ public class SearchRequestTest {
     SearchFields expectedSearchFields = SearchFields.newBuilder().withField("field_1").build();
     FacetQuery expectedFacetQuery = FacetFieldsQuery.newBuilder().withField("field_3").build();
     SearchRequest actual =
-        SearchRequest.newBuilder("some query")
+        SearchRequest.newBuilder()
+            .withQuery("some query")
             .withSearchFields("field_1")
             .withFacetFields("field_3")
             .build();
@@ -64,10 +66,17 @@ public class SearchRequestTest {
   }
 
   @Test
+  public void emptyBuild() {
+    SearchRequest built = SearchRequest.newBuilder().build();
+    Assert.assertEquals(built.getQuery(), QueryString.getMatchAllQuery());
+  }
+
+  @Test
   public void failsWithNullQuery() {
     Exception thrown =
         Assert.assertThrows(
-            IllegalArgumentException.class, () -> SearchRequest.newBuilder((String) null).build());
+            IllegalArgumentException.class,
+            () -> SearchRequest.newBuilder().withQuery(null).build());
     Assert.assertEquals("Query cannot be null", thrown.getMessage());
   }
 }


### PR DESCRIPTION
Minor changes to `SearchRequest` builder api as per documentation feedback. Users will be explicitly specifying a query term.

##### Before
`SearchRequest.newBuilder("my query").build()`

##### After
`SearchRequest.newBuilder().withQuery("my query").build()`