### PR TITLE
refactor: Match all query builder to search

### DIFF
--- a/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
@@ -100,6 +100,18 @@ public final class SearchRequest {
     return new Builder();
   }
 
+  /**
+   * Builder object that matches all documents in the collection
+   *
+   * <p>Note: Avoid using {@code withQuery()} construct with this builder, it may override pre-built
+   * match all query syntax and may not function as expected.
+   *
+   * @return {@link SearchRequest.Builder} object that includes a match all {@code query}
+   */
+  public static Builder matchAll() {
+    return newBuilder();
+  }
+
   public static final class Builder {
 
     private Query query;

--- a/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
@@ -72,6 +72,12 @@ public class SearchRequestTest {
   }
 
   @Test
+  public void matchAllBuild() {
+    SearchRequest built = SearchRequest.matchAll().build();
+    Assert.assertEquals(built.getQuery(), QueryString.getMatchAllQuery());
+  }
+
+  @Test
   public void failsWithNullQuery() {
     Exception thrown =
         Assert.assertThrows(


### PR DESCRIPTION
Allow users to perform match all queries:

```java
// get all documents
SearchRequest.matchAll().build();
```

```java
// filter only search
SearchRequest.matchAll().withFilter(myFilter).build();
```

```java
// facet only search
SearchRequest.matchAll().withFacetFields("fieldname").build();
```