### PR TITLE
refactor: Field selection api for search

### DIFF
--- a/client/src/main/java/com/tigrisdata/db/client/TypeConverter.java
+++ b/client/src/main/java/com/tigrisdata/db/client/TypeConverter.java
@@ -165,7 +165,9 @@ final class TypeConverter {
         Api.SearchRequest.newBuilder()
             .setDb(databaseName)
             .setCollection(collectionName)
-            .setQ(req.getQuery().toJSON(objectMapper));
+            .setQ(req.getQuery().toJSON(objectMapper))
+            .addAllIncludeFields(req.getIncludeFields())
+            .addAllExcludeFields(req.getExcludeFields());
     if (Objects.nonNull(req.getSearchFields())) {
       builder.addAllSearchFields(req.getSearchFields().getFields());
     }
@@ -177,9 +179,6 @@ final class TypeConverter {
     }
     if (Objects.nonNull(req.getSortOrders())) {
       builder.setSort(ByteString.copyFromUtf8(req.getSortOrders().toJSON(objectMapper)));
-    }
-    if (Objects.nonNull(req.getReadFields())) {
-      builder.setFields(ByteString.copyFromUtf8(req.getReadFields().toJSON(objectMapper)));
     }
     if (Objects.nonNull(options)) {
       builder.setPage(options.getPage());

--- a/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
@@ -14,9 +14,11 @@
 
 package com.tigrisdata.db.client.search;
 
-import com.tigrisdata.db.client.ReadFields;
 import com.tigrisdata.db.client.TigrisFilter;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /** Builder class to create a Search request */
 public final class SearchRequest {
@@ -26,7 +28,8 @@ public final class SearchRequest {
   private final TigrisFilter filter;
   private final FacetQuery facetQuery;
   private final SortOrder sortOrder;
-  private final ReadFields readFields;
+  private final List<String> includeFields;
+  private final List<String> excludeFields;
 
   private SearchRequest(Builder builder) {
     this.query = builder.query;
@@ -34,7 +37,8 @@ public final class SearchRequest {
     this.searchFields = builder.searchFields;
     this.facetQuery = builder.facetQuery;
     this.sortOrder = builder.sortOrder;
-    this.readFields = builder.fields;
+    this.includeFields = Collections.unmodifiableList(builder.includeFields);
+    this.excludeFields = Collections.unmodifiableList(builder.excludeFields);
   }
 
   /**
@@ -83,12 +87,21 @@ public final class SearchRequest {
   }
 
   /**
-   * Gets the document fields to include/exclude in search results
+   * Gets list of fields to include in returned documents
    *
-   * @return {@link ReadFields} or null
+   * @return non-null immutable {@link List}
    */
-  public ReadFields getReadFields() {
-    return readFields;
+  public List<String> getIncludeFields() {
+    return includeFields;
+  }
+
+  /**
+   * Gets list of fields to exclude from returned documents
+   *
+   * @return non-null immutable {@link List}
+   */
+  public List<String> getExcludeFields() {
+    return excludeFields;
   }
 
   /**
@@ -119,10 +132,13 @@ public final class SearchRequest {
     private SearchFields searchFields;
     private FacetQuery facetQuery;
     private SortOrder sortOrder;
-    private ReadFields fields;
+    private final List<String> includeFields;
+    private final List<String> excludeFields;
 
     private Builder() {
       this.query = QueryString.getMatchAllQuery();
+      this.includeFields = new ArrayList<>();
+      this.excludeFields = new ArrayList<>();
     }
 
     /**
@@ -173,7 +189,7 @@ public final class SearchRequest {
     /**
      * Optional - Sets the facet fields to categorically arrange indexed terms
      *
-     * @param fields {@link }
+     * @param fields Collection field names
      * @return {@link SearchRequest.Builder}
      * @see #withFacetQuery(FacetQuery)
      */
@@ -206,13 +222,24 @@ public final class SearchRequest {
     }
 
     /**
-     * Optional - Sets the document fields to include/exclude in search results
+     * Optional - Sets collection fields to include in returned documents
      *
-     * @param fields {@link ReadFields}
+     * @param fields Collection field names
      * @return {@link SearchRequest.Builder}
      */
-    public Builder withReadFields(ReadFields fields) {
-      this.fields = fields;
+    public Builder withIncludeFields(String... fields) {
+      this.includeFields.addAll(Arrays.asList(fields));
+      return this;
+    }
+
+    /**
+     * Optional - Sets collection fields to exclude from returned documents
+     *
+     * @param fields Collection field names
+     * @return {@link SearchRequest.Builder}
+     */
+    public Builder withExcludeFields(String... fields) {
+      this.excludeFields.addAll(Arrays.asList(fields));
       return this;
     }
 

--- a/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
@@ -18,7 +18,9 @@ import com.tigrisdata.db.client.TigrisFilter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /** Builder class to create a Search request */
 public final class SearchRequest {
@@ -37,8 +39,10 @@ public final class SearchRequest {
     this.searchFields = builder.searchFields;
     this.facetQuery = builder.facetQuery;
     this.sortOrder = builder.sortOrder;
-    this.includeFields = Collections.unmodifiableList(builder.includeFields);
-    this.excludeFields = Collections.unmodifiableList(builder.excludeFields);
+    ArrayList<String> includeFields = new ArrayList<>(builder.includeFields);
+    this.includeFields = Collections.unmodifiableList(includeFields);
+    ArrayList<String> excludeFields = new ArrayList<>(builder.excludeFields);
+    this.excludeFields = Collections.unmodifiableList(excludeFields);
   }
 
   /**
@@ -132,13 +136,13 @@ public final class SearchRequest {
     private SearchFields searchFields;
     private FacetQuery facetQuery;
     private SortOrder sortOrder;
-    private final List<String> includeFields;
-    private final List<String> excludeFields;
+    private final Set<String> includeFields;
+    private final Set<String> excludeFields;
 
     private Builder() {
       this.query = QueryString.getMatchAllQuery();
-      this.includeFields = new ArrayList<>();
-      this.excludeFields = new ArrayList<>();
+      this.includeFields = new LinkedHashSet<>();
+      this.excludeFields = new LinkedHashSet<>();
     }
 
     /**

--- a/client/src/test/java/com/tigrisdata/db/client/StandardTigrisCollectionTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/StandardTigrisCollectionTest.java
@@ -135,7 +135,7 @@ public class StandardTigrisCollectionTest {
         SearchRequest.newBuilder()
             .withQuery("my search string")
             .withFacetQuery(FacetFieldsQuery.newBuilder().withField("name").build())
-            .withReadFields(ReadFields.newBuilder().includeField("other_field").build())
+            .withIncludeFields("other_field")
             .withFilter(
                 Filters.and(
                     Filters.eq("first_key", "first_value"), Filters.eq("some_key", "some value")))

--- a/client/src/test/java/com/tigrisdata/db/client/TypeConverterTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/TypeConverterTest.java
@@ -94,7 +94,8 @@ public class TypeConverterTest {
     Assert.assertNotNull(apiSearchRequest.getFacet());
     Assert.assertNotNull(apiSearchRequest.getFilter());
     Assert.assertNotNull(apiSearchRequest.getSort());
-    Assert.assertNotNull(apiSearchRequest.getFields());
+    Assert.assertNotNull(apiSearchRequest.getIncludeFieldsList());
+    Assert.assertNotNull(apiSearchRequest.getExcludeFieldsList());
     Assert.assertEquals(options.getPage(), apiSearchRequest.getPage());
     Assert.assertEquals(options.getPerPage(), apiSearchRequest.getPageSize());
   }

--- a/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
@@ -15,8 +15,10 @@
 package com.tigrisdata.db.client.search;
 
 import com.tigrisdata.db.client.Filters;
-import com.tigrisdata.db.client.ReadFields;
 import com.tigrisdata.db.client.TigrisFilter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,7 +31,7 @@ public class SearchRequestTest {
     SearchFields expectedSearchFields = SearchFields.newBuilder().withField("field_1").build();
     TigrisFilter expectedFilter = Filters.eq("field_2", "otherValue");
     FacetQuery expectedFacetQuery = FacetFieldsQuery.newBuilder().withField("field_3").build();
-    ReadFields expectedReadFields = ReadFields.newBuilder().includeField("field_1").build();
+    List<String> expectedIncludeFields = Collections.singletonList("field_1");
 
     SearchRequest actual =
         SearchRequest.newBuilder()
@@ -37,7 +39,7 @@ public class SearchRequestTest {
             .withSearchFields(expectedSearchFields)
             .withFacetQuery(expectedFacetQuery)
             .withFilter(expectedFilter)
-            .withReadFields(expectedReadFields)
+            .withIncludeFields(expectedIncludeFields.get(0))
             .build();
 
     Assert.assertNotNull(actual);
@@ -45,7 +47,8 @@ public class SearchRequestTest {
     Assert.assertEquals(expectedSearchFields, actual.getSearchFields());
     Assert.assertEquals(expectedFacetQuery, actual.getFacetQuery());
     Assert.assertEquals(expectedFilter, actual.getFilter());
-    Assert.assertEquals(expectedReadFields, actual.getReadFields());
+    Assert.assertEquals(expectedIncludeFields, actual.getIncludeFields());
+    Assert.assertEquals(0, actual.getExcludeFields().size());
     Assert.assertNull(actual.getSortOrders());
   }
 
@@ -59,10 +62,14 @@ public class SearchRequestTest {
             .withQuery("some query")
             .withSearchFields("field_1")
             .withFacetFields("field_3")
+            .withExcludeFields("field_4", "field_5")
+            .withIncludeFields("field_6")
             .build();
     Assert.assertEquals(expectedQuery, actual.getQuery());
     Assert.assertEquals(expectedSearchFields, actual.getSearchFields());
     Assert.assertEquals(expectedFacetQuery, actual.getFacetQuery());
+    Assert.assertEquals(Arrays.asList("field_6"), actual.getIncludeFields());
+    Assert.assertEquals(Arrays.asList("field_4", "field_5"), actual.getExcludeFields());
   }
 
   @Test


### PR DESCRIPTION
- Capability to specify field selection for documents returned in search results:

```java
    SearchRequest request =
        SearchRequest.newBuilder()
            .withQuery("some query")
            .withSearchFields("field_1")
            .withFacetFields("field_3")
            .withExcludeFields("field_4", "field_5")
            .withIncludeFields("field_6")
            .build();
```