### PR TITLE
refactor: Singular search method

### DIFF
--- a/client/src/main/java/com/tigrisdata/db/client/AbstractTigrisCollection.java
+++ b/client/src/main/java/com/tigrisdata/db/client/AbstractTigrisCollection.java
@@ -18,6 +18,7 @@ import static com.tigrisdata.db.client.Constants.INSERT_FAILED;
 import static com.tigrisdata.db.client.Constants.INSERT_OR_REPLACE_FAILED;
 import static com.tigrisdata.db.client.Constants.JSON_SER_DE_ERROR;
 import static com.tigrisdata.db.client.Constants.READ_FAILED;
+import static com.tigrisdata.db.client.Constants.SEARCH_FAILED;
 import static com.tigrisdata.db.client.Constants.UPDATE_FAILED;
 import static com.tigrisdata.db.client.TypeConverter.toDeleteRequest;
 import static com.tigrisdata.db.client.TypeConverter.toReadRequest;
@@ -27,9 +28,13 @@ import static com.tigrisdata.db.client.TypeConverter.toUpdateRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tigrisdata.db.api.v1.grpc.Api;
+import com.tigrisdata.db.api.v1.grpc.Api.SearchResponse;
 import com.tigrisdata.db.api.v1.grpc.TigrisGrpc;
 import com.tigrisdata.db.client.config.TigrisConfiguration;
 import com.tigrisdata.db.client.error.TigrisException;
+import com.tigrisdata.db.client.search.SearchRequest;
+import com.tigrisdata.db.client.search.SearchRequestOptions;
+import com.tigrisdata.db.client.search.SearchResult;
 import com.tigrisdata.db.type.TigrisCollectionType;
 import io.grpc.StatusRuntimeException;
 import java.util.Iterator;
@@ -91,6 +96,23 @@ abstract class AbstractTigrisCollection<T extends TigrisCollectionType> {
     } catch (StatusRuntimeException statusRuntimeException) {
       throw new TigrisException(
           READ_FAILED,
+          TypeConverter.extractTigrisError(statusRuntimeException),
+          statusRuntimeException);
+    }
+  }
+
+  protected Iterator<SearchResult<T>> searchInternal(
+      SearchRequest request, SearchRequestOptions options) throws TigrisException {
+    Api.SearchRequest apiSearchRequest =
+        TypeConverter.toSearchRequest(databaseName, collectionName, request, options, objectMapper);
+    try {
+      Iterator<Api.SearchResponse> resp = blockingStub.search(apiSearchRequest);
+      Function<SearchResponse, SearchResult<T>> converter =
+          r -> SearchResult.from(r, objectMapper, collectionTypeClass);
+      return Utilities.transformIterator(resp, converter);
+    } catch (StatusRuntimeException statusRuntimeException) {
+      throw new TigrisException(
+          SEARCH_FAILED,
           TypeConverter.extractTigrisError(statusRuntimeException),
           statusRuntimeException);
     }

--- a/client/src/main/java/com/tigrisdata/db/client/TigrisCollection.java
+++ b/client/src/main/java/com/tigrisdata/db/client/TigrisCollection.java
@@ -105,11 +105,11 @@ public interface TigrisCollection<T extends TigrisCollectionType>
    *
    * @param request search request to execute
    * @param options search pagination options
-   * @return stream of search results
+   * @return Optional Search result
    * @throws TigrisException in case of error
    * @see #search(SearchRequest)
    */
-  Iterator<SearchResult<T>> search(SearchRequest request, SearchRequestOptions options)
+  Optional<SearchResult<T>> search(SearchRequest request, SearchRequestOptions options)
       throws TigrisException;
 
   /**


### PR DESCRIPTION
Server does not support a streamed response when pagination options are used (The iterator has single entiry). Hence, replicating same in SDK.