### PR TITLE
feat: Sorting for search results

### DIFF
--- a/client/src/main/java/com/tigrisdata/db/client/FieldSort.java
+++ b/client/src/main/java/com/tigrisdata/db/client/FieldSort.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Represents a collection field and corresponding sort order */
+public final class FieldSort implements TigrisSort {
+
+  private final String fieldName;
+  private final SortingOperator operator;
+  private Map<String, Object> cachedMap;
+
+  FieldSort(String fieldName, SortingOperator op) {
+    this.fieldName = fieldName;
+    this.operator = op;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public Map<String, Object> toMap() {
+    if (cachedMap == null) {
+      cachedMap =
+          Collections.unmodifiableMap(
+              new HashMap<String, String>() {
+                {
+                  put(fieldName, operator.getOperator());
+                }
+              });
+    }
+    return cachedMap;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String getFieldName() {
+    return fieldName;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    FieldSort fieldSort = (FieldSort) o;
+
+    if (!Objects.equals(fieldName, fieldSort.fieldName)) {
+      return false;
+    }
+    return operator == fieldSort.operator;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = fieldName != null ? fieldName.hashCode() : 0;
+    result = 31 * result + (operator != null ? operator.hashCode() : 0);
+    return result;
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/FieldSort.java
+++ b/client/src/main/java/com/tigrisdata/db/client/FieldSort.java
@@ -23,17 +23,17 @@ import java.util.Objects;
 public final class FieldSort implements TigrisSort {
 
   private final String fieldName;
-  private final SortingOperator operator;
+  private final SortOrder operator;
   private Map<String, Object> cachedMap;
 
-  FieldSort(String fieldName, SortingOperator op) {
+  FieldSort(String fieldName, SortOrder op) {
     this.fieldName = fieldName;
     this.operator = op;
   }
 
   /** {@inheritDoc} */
   @Override
-  public Map<String, Object> toMap() {
+  public Map<String, Object> getOrder() {
     if (cachedMap == null) {
       cachedMap =
           Collections.unmodifiableMap(

--- a/client/src/main/java/com/tigrisdata/db/client/Sort.java
+++ b/client/src/main/java/com/tigrisdata/db/client/Sort.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client;
+
+/** Helper class to construct {@link TigrisSort} orders */
+public final class Sort {
+  private Sort() {}
+
+  /**
+   * Creates ascending sort order for given key
+   *
+   * @param key collection field name
+   * @return constructed {@link FieldSort} of ascending order
+   */
+  public static FieldSort ascending(String key) {
+    return new FieldSort(key, SortingOperator.ASC);
+  }
+
+  /**
+   * Creates descending sort order for given key
+   *
+   * @param key collection field name
+   * @return constructed {@link FieldSort} of descending order
+   */
+  public static FieldSort descending(String key) {
+    return new FieldSort(key, SortingOperator.DESC);
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/Sort.java
+++ b/client/src/main/java/com/tigrisdata/db/client/Sort.java
@@ -19,22 +19,22 @@ public final class Sort {
   private Sort() {}
 
   /**
-   * Creates ascending sort order for given key
+   * Creates ascending sort order for given field name
    *
-   * @param key collection field name
+   * @param fieldName collection field name
    * @return constructed {@link FieldSort} of ascending order
    */
-  public static FieldSort ascending(String key) {
-    return new FieldSort(key, SortingOperator.ASC);
+  public static FieldSort ascending(String fieldName) {
+    return new FieldSort(fieldName, SortOrder.ASC);
   }
 
   /**
-   * Creates descending sort order for given key
+   * Creates descending sort order for given field name
    *
-   * @param key collection field name
+   * @param fieldName collection field name
    * @return constructed {@link FieldSort} of descending order
    */
-  public static FieldSort descending(String key) {
-    return new FieldSort(key, SortingOperator.DESC);
+  public static FieldSort descending(String fieldName) {
+    return new FieldSort(fieldName, SortOrder.DESC);
   }
 }

--- a/client/src/main/java/com/tigrisdata/db/client/SortOrder.java
+++ b/client/src/main/java/com/tigrisdata/db/client/SortOrder.java
@@ -14,13 +14,13 @@
 
 package com.tigrisdata.db.client;
 
-enum SortingOperator {
+enum SortOrder {
   ASC("$asc"),
   DESC("$desc");
 
   private final String operator;
 
-  SortingOperator(String operator) {
+  SortOrder(String operator) {
     this.operator = operator;
   }
 

--- a/client/src/main/java/com/tigrisdata/db/client/SortingOperator.java
+++ b/client/src/main/java/com/tigrisdata/db/client/SortingOperator.java
@@ -12,9 +12,19 @@
  * limitations under the License.
  */
 
-package com.tigrisdata.db.client.search;
+package com.tigrisdata.db.client;
 
-import com.tigrisdata.db.client.JSONSerializable;
+enum SortingOperator {
+  ASC("$asc"),
+  DESC("$desc");
 
-/** Interface to construct sorting order for search results */
-public interface SortOrder extends JSONSerializable {}
+  private final String operator;
+
+  SortingOperator(String operator) {
+    this.operator = operator;
+  }
+
+  public String getOperator() {
+    return operator;
+  }
+}

--- a/client/src/main/java/com/tigrisdata/db/client/TigrisSort.java
+++ b/client/src/main/java/com/tigrisdata/db/client/TigrisSort.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client;
+
+import java.util.Map;
+
+/** Represents the sorting order */
+public interface TigrisSort {
+
+  /**
+   * Sort order representation as Key, Value pairs
+   *
+   * @return non-null immutable {@link Map}
+   */
+  public Map<String, Object> toMap();
+
+  /**
+   * Gets collection field name that this order represents
+   *
+   * @return {@link String}
+   */
+  public String getFieldName();
+}

--- a/client/src/main/java/com/tigrisdata/db/client/TigrisSort.java
+++ b/client/src/main/java/com/tigrisdata/db/client/TigrisSort.java
@@ -24,12 +24,12 @@ public interface TigrisSort {
    *
    * @return non-null immutable {@link Map}
    */
-  public Map<String, Object> toMap();
+  Map<String, Object> getOrder();
 
   /**
    * Gets collection field name that this order represents
    *
    * @return {@link String}
    */
-  public String getFieldName();
+  String getFieldName();
 }

--- a/client/src/main/java/com/tigrisdata/db/client/TypeConverter.java
+++ b/client/src/main/java/com/tigrisdata/db/client/TypeConverter.java
@@ -177,8 +177,8 @@ final class TypeConverter {
     if (Objects.nonNull(req.getFacetQuery())) {
       builder.setFacet(ByteString.copyFromUtf8(req.getFacetQuery().toJSON(objectMapper)));
     }
-    if (Objects.nonNull(req.getSortOrders())) {
-      builder.setSort(ByteString.copyFromUtf8(req.getSortOrders().toJSON(objectMapper)));
+    if (Objects.nonNull(req.getSortingOrder())) {
+      builder.setSort(ByteString.copyFromUtf8(req.getSortingOrder().toJSON(objectMapper)));
     }
     if (Objects.nonNull(options)) {
       builder.setPage(options.getPage());

--- a/client/src/main/java/com/tigrisdata/db/client/search/FacetFieldsQuery.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/FacetFieldsQuery.java
@@ -31,6 +31,7 @@ public final class FacetFieldsQuery implements FacetQuery {
   private static final FacetFieldsQuery EMPTY = newBuilder().build();
 
   private final Map<String, FacetQueryOptions> internalMap;
+  private String cachedJSON;
 
   private FacetFieldsQuery(Builder builder) {
     this.internalMap = Collections.unmodifiableMap(builder.fieldMap);
@@ -65,6 +66,9 @@ public final class FacetFieldsQuery implements FacetQuery {
 
   @Override
   public String toJSON(ObjectMapper objectMapper) {
+    if (Objects.nonNull(cachedJSON)) {
+      return cachedJSON;
+    }
     Function<FacetQueryOptions, Map<String, String>> toOptionsMap =
         o ->
             new HashMap<String, String>() {
@@ -78,7 +82,8 @@ public final class FacetFieldsQuery implements FacetQuery {
         internalMap.entrySet().stream()
             .collect(Collectors.toMap(Entry::getKey, e -> toOptionsMap.apply(e.getValue())));
     try {
-      return objectMapper.writeValueAsString(fieldOptionsMap);
+      cachedJSON = objectMapper.writeValueAsString(fieldOptionsMap);
+      return cachedJSON;
     } catch (JsonProcessingException ex) {
       throw new IllegalArgumentException("Failed to serialize FacetFields to JSON", ex);
     }

--- a/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
@@ -15,6 +15,7 @@
 package com.tigrisdata.db.client.search;
 
 import com.tigrisdata.db.client.TigrisFilter;
+import com.tigrisdata.db.client.TigrisSort;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,7 +30,7 @@ public final class SearchRequest {
   private final SearchFields searchFields;
   private final TigrisFilter filter;
   private final FacetQuery facetQuery;
-  private final SortOrder sortOrder;
+  private final SortingOrder sortOrder;
   private final List<String> includeFields;
   private final List<String> excludeFields;
 
@@ -84,9 +85,9 @@ public final class SearchRequest {
   /**
    * Gets the Order to sort the search results
    *
-   * @return {@link SortOrder} or null
+   * @return {@link SortingOrder} or null
    */
-  public SortOrder getSortOrders() {
+  public SortingOrder getSortingOrder() {
     return sortOrder;
   }
 
@@ -135,7 +136,7 @@ public final class SearchRequest {
     private TigrisFilter filter;
     private SearchFields searchFields;
     private FacetQuery facetQuery;
-    private SortOrder sortOrder;
+    private SortingOrder sortOrder;
     private final Set<String> includeFields;
     private final Set<String> excludeFields;
 
@@ -214,14 +215,26 @@ public final class SearchRequest {
     }
 
     /**
-     * Optional - Sets the SortOrder to sorts search results according to specified attributes and
+     * Optional - Sets the SortingOrder to sort search results according to specified attributes and
      * indicated order
      *
-     * @param sortOrder {@link SortOrder}
+     * @param sortOrder {@link SortingOrder}
      * @return {@link SearchRequest.Builder}
      */
-    public Builder withSortOrder(SortOrder sortOrder) {
+    public Builder withSortingOrder(SortingOrder sortOrder) {
       this.sortOrder = sortOrder;
+      return this;
+    }
+
+    /**
+     * Optional - Sets the SortingOrder to sort search results according to specified attributes and
+     * indicated order
+     *
+     * @param orders {@link TigrisSort}
+     * @return {@link SearchRequest.Builder}
+     */
+    public Builder withSortingOrders(TigrisSort... orders) {
+      this.sortOrder = SortingOrder.newBuilder().withOrder(orders).build();
       return this;
     }
 

--- a/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SearchRequest.java
@@ -221,7 +221,7 @@ public final class SearchRequest {
      * @param sortOrder {@link SortingOrder}
      * @return {@link SearchRequest.Builder}
      */
-    public Builder withSortingOrder(SortingOrder sortOrder) {
+    public Builder withSort(SortingOrder sortOrder) {
       this.sortOrder = sortOrder;
       return this;
     }
@@ -233,7 +233,7 @@ public final class SearchRequest {
      * @param orders {@link TigrisSort}
      * @return {@link SearchRequest.Builder}
      */
-    public Builder withSortingOrders(TigrisSort... orders) {
+    public Builder withSort(TigrisSort... orders) {
       this.sortOrder = SortingOrder.newBuilder().withOrder(orders).build();
       return this;
     }

--- a/client/src/main/java/com/tigrisdata/db/client/search/SortingOrder.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SortingOrder.java
@@ -54,7 +54,7 @@ public final class SortingOrder implements JSONSerializable {
 
     List<Map<String, Object>> list = new ArrayList<>();
     for (TigrisSort sort : orders) {
-      list.add(sort.toMap());
+      list.add(sort.getOrder());
     }
     try {
       cachedJSON = objectMapper.writeValueAsString(list);

--- a/client/src/main/java/com/tigrisdata/db/client/search/SortingOrder.java
+++ b/client/src/main/java/com/tigrisdata/db/client/search/SortingOrder.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tigrisdata.db.client.JSONSerializable;
+import com.tigrisdata.db.client.TigrisSort;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Interface to construct sorting order for search results */
+public final class SortingOrder implements JSONSerializable {
+
+  private final List<TigrisSort> orders;
+  private String cachedJSON;
+
+  private SortingOrder(Builder builder) {
+    orders = new ArrayList<>();
+    orders.addAll(builder.sortOrders.values());
+  }
+
+  /**
+   * Gets sorting order of fields
+   *
+   * @return non-null immutable {@link List}
+   */
+  public List<TigrisSort> get() {
+    return Collections.unmodifiableList(orders);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public String toJSON(ObjectMapper objectMapper) {
+    if (Objects.nonNull(cachedJSON)) {
+      return cachedJSON;
+    }
+
+    List<Map<String, Object>> list = new ArrayList<>();
+    for (TigrisSort sort : orders) {
+      list.add(sort.toMap());
+    }
+    try {
+      cachedJSON = objectMapper.writeValueAsString(list);
+      return cachedJSON;
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(
+          "This was caused because the SortingOrder's JSON serialization raised errors", e);
+    }
+  }
+
+  /**
+   * Builder API for {@link SortingOrder}
+   *
+   * @return {@link SortingOrder.Builder}
+   */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private final LinkedHashMap<String, TigrisSort> sortOrders;
+
+    private Builder() {
+      sortOrders = new LinkedHashMap<>();
+    }
+
+    /**
+     * Adds field names and their corresponding sort orders to the sequence
+     *
+     * @param orders {@link TigrisSort}
+     * @return {@link SortingOrder.Builder}
+     */
+    public Builder withOrder(TigrisSort... orders) {
+      for (TigrisSort o : orders) {
+        sortOrders.put(o.getFieldName(), o);
+      }
+      return this;
+    }
+
+    /**
+     * Constructs a {@link SortingOrder}
+     *
+     * @return {@link SortingOrder}
+     */
+    public SortingOrder build() {
+      return new SortingOrder(this);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SortingOrder that = (SortingOrder) o;
+
+    return Objects.equals(orders, that.orders);
+  }
+
+  @Override
+  public int hashCode() {
+    return orders != null ? orders.hashCode() : 0;
+  }
+}

--- a/client/src/test/java/com/tigrisdata/db/client/FieldSortTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/FieldSortTest.java
@@ -23,10 +23,10 @@ public class FieldSortTest {
   @Test
   public void testToMap() {
     String expectedFieldName = "parent.nested_field";
-    FieldSort fs = new FieldSort(expectedFieldName, SortingOperator.DESC);
+    FieldSort fs = new FieldSort(expectedFieldName, SortOrder.DESC);
     Assert.assertEquals(expectedFieldName, fs.getFieldName());
-    Assert.assertEquals(1, fs.toMap().size());
-    Assert.assertEquals(SortingOperator.DESC.getOperator(), fs.toMap().get(expectedFieldName));
+    Assert.assertEquals(1, fs.getOrder().size());
+    Assert.assertEquals(SortOrder.DESC.getOperator(), fs.getOrder().get(expectedFieldName));
   }
 
   @Test

--- a/client/src/test/java/com/tigrisdata/db/client/FieldSortTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/FieldSortTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FieldSortTest {
+
+  @Test
+  public void testToMap() {
+    String expectedFieldName = "parent.nested_field";
+    FieldSort fs = new FieldSort(expectedFieldName, SortingOperator.DESC);
+    Assert.assertEquals(expectedFieldName, fs.getFieldName());
+    Assert.assertEquals(1, fs.toMap().size());
+    Assert.assertEquals(SortingOperator.DESC.getOperator(), fs.toMap().get(expectedFieldName));
+  }
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(FieldSort.class).withIgnoredFields("cachedMap").verify();
+  }
+}

--- a/client/src/test/java/com/tigrisdata/db/client/SortTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/SortTest.java
@@ -27,11 +27,11 @@ public class SortTest {
     Map<String, String> expected =
         new HashMap<String, String>() {
           {
-            put("field_1", SortingOperator.ASC.getOperator());
+            put("field_1", SortOrder.ASC.getOperator());
           }
         };
 
-    Assert.assertEquals(expected, sort.toMap());
+    Assert.assertEquals(expected, sort.getOrder());
   }
 
   @Test
@@ -40,10 +40,10 @@ public class SortTest {
     Map<String, String> expected =
         new HashMap<String, String>() {
           {
-            put("field_1", SortingOperator.DESC.getOperator());
+            put("field_1", SortOrder.DESC.getOperator());
           }
         };
 
-    Assert.assertEquals(expected, sort.toMap());
+    Assert.assertEquals(expected, sort.getOrder());
   }
 }

--- a/client/src/test/java/com/tigrisdata/db/client/SortTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/SortTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SortTest {
+
+  @Test
+  public void testAscending() {
+    TigrisSort sort = Sort.ascending("field_1");
+    Map<String, String> expected =
+        new HashMap<String, String>() {
+          {
+            put("field_1", SortingOperator.ASC.getOperator());
+          }
+        };
+
+    Assert.assertEquals(expected, sort.toMap());
+  }
+
+  @Test
+  public void testDescending() {
+    TigrisSort sort = Sort.descending("field_1");
+    Map<String, String> expected =
+        new HashMap<String, String>() {
+          {
+            put("field_1", SortingOperator.DESC.getOperator());
+          }
+        };
+
+    Assert.assertEquals(expected, sort.toMap());
+  }
+}

--- a/client/src/test/java/com/tigrisdata/db/client/TypeConverterTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/TypeConverterTest.java
@@ -99,4 +99,14 @@ public class TypeConverterTest {
     Assert.assertEquals(options.getPage(), apiSearchRequest.getPage());
     Assert.assertEquals(options.getPerPage(), apiSearchRequest.getPageSize());
   }
+
+  @Test
+  public void toSearchRequest_withSortOrder() {
+    SearchRequest input =
+        SearchRequest.newBuilder().withSortingOrders(Sort.descending("field_1")).build();
+    Api.SearchRequest apiSearchRequest =
+        TypeConverter.toSearchRequest(DB_NAME, COLLECTION_NAME, input, null, DEFAULT_OBJECT_MAPPER);
+    Assert.assertNotNull(apiSearchRequest.getSort());
+    Assert.assertEquals("[{\"field_1\":\"$desc\"}]", apiSearchRequest.getSort().toStringUtf8());
+  }
 }

--- a/client/src/test/java/com/tigrisdata/db/client/TypeConverterTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/TypeConverterTest.java
@@ -102,8 +102,7 @@ public class TypeConverterTest {
 
   @Test
   public void toSearchRequest_withSortOrder() {
-    SearchRequest input =
-        SearchRequest.newBuilder().withSortingOrders(Sort.descending("field_1")).build();
+    SearchRequest input = SearchRequest.newBuilder().withSort(Sort.descending("field_1")).build();
     Api.SearchRequest apiSearchRequest =
         TypeConverter.toSearchRequest(DB_NAME, COLLECTION_NAME, input, null, DEFAULT_OBJECT_MAPPER);
     Assert.assertNotNull(apiSearchRequest.getSort());

--- a/client/src/test/java/com/tigrisdata/db/client/search/FacetFieldsQueryTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/FacetFieldsQueryTest.java
@@ -39,7 +39,7 @@ public class FacetFieldsQueryTest {
 
   @Test
   public void equalsContract() {
-    EqualsVerifier.forClass(FacetFieldsQuery.class).verify();
+    EqualsVerifier.forClass(FacetFieldsQuery.class).withIgnoredFields("cachedJSON").verify();
   }
 
   @Test

--- a/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
@@ -14,7 +14,9 @@
 
 package com.tigrisdata.db.client.search;
 
+import com.tigrisdata.db.client.FieldSort;
 import com.tigrisdata.db.client.Filters;
+import com.tigrisdata.db.client.Sort;
 import com.tigrisdata.db.client.TigrisFilter;
 import java.util.Arrays;
 import java.util.Collections;
@@ -24,13 +26,14 @@ import org.junit.Test;
 
 public class SearchRequestTest {
 
-  // TODO: Add sort orders to this test
   @Test
   public void build() {
     QueryString expectedQuery = QueryString.getMatchAllQuery();
     SearchFields expectedSearchFields = SearchFields.newBuilder().withField("field_1").build();
     TigrisFilter expectedFilter = Filters.eq("field_2", "otherValue");
     FacetQuery expectedFacetQuery = FacetFieldsQuery.newBuilder().withField("field_3").build();
+    SortingOrder expectedSortingOrder =
+        SortingOrder.newBuilder().withOrder(Sort.ascending("field_4")).build();
     List<String> expectedIncludeFields = Collections.singletonList("field_1");
 
     SearchRequest actual =
@@ -40,6 +43,7 @@ public class SearchRequestTest {
             .withFacetQuery(expectedFacetQuery)
             .withFilter(expectedFilter)
             .withIncludeFields(expectedIncludeFields.get(0))
+            .withSortingOrder(expectedSortingOrder)
             .build();
 
     Assert.assertNotNull(actual);
@@ -49,7 +53,7 @@ public class SearchRequestTest {
     Assert.assertEquals(expectedFilter, actual.getFilter());
     Assert.assertEquals(expectedIncludeFields, actual.getIncludeFields());
     Assert.assertEquals(0, actual.getExcludeFields().size());
-    Assert.assertNull(actual.getSortOrders());
+    Assert.assertEquals(expectedSortingOrder, actual.getSortingOrder());
   }
 
   @Test
@@ -57,6 +61,7 @@ public class SearchRequestTest {
     Query expectedQuery = QueryString.newBuilder("some query").build();
     SearchFields expectedSearchFields = SearchFields.newBuilder().withField("field_1").build();
     FacetQuery expectedFacetQuery = FacetFieldsQuery.newBuilder().withField("field_3").build();
+    FieldSort expectedSort = Sort.descending("field_4");
     SearchRequest actual =
         SearchRequest.newBuilder()
             .withQuery("some query")
@@ -64,12 +69,14 @@ public class SearchRequestTest {
             .withFacetFields("field_3")
             .withExcludeFields("field_4", "field_5")
             .withIncludeFields("field_6")
+            .withSortingOrders(expectedSort)
             .build();
     Assert.assertEquals(expectedQuery, actual.getQuery());
     Assert.assertEquals(expectedSearchFields, actual.getSearchFields());
     Assert.assertEquals(expectedFacetQuery, actual.getFacetQuery());
     Assert.assertEquals(Arrays.asList("field_6"), actual.getIncludeFields());
     Assert.assertEquals(Arrays.asList("field_4", "field_5"), actual.getExcludeFields());
+    Assert.assertEquals(Collections.singletonList(expectedSort), actual.getSortingOrder().get());
   }
 
   @Test

--- a/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/SearchRequestTest.java
@@ -43,7 +43,7 @@ public class SearchRequestTest {
             .withFacetQuery(expectedFacetQuery)
             .withFilter(expectedFilter)
             .withIncludeFields(expectedIncludeFields.get(0))
-            .withSortingOrder(expectedSortingOrder)
+            .withSort(expectedSortingOrder)
             .build();
 
     Assert.assertNotNull(actual);
@@ -69,7 +69,7 @@ public class SearchRequestTest {
             .withFacetFields("field_3")
             .withExcludeFields("field_4", "field_5")
             .withIncludeFields("field_6")
-            .withSortingOrders(expectedSort)
+            .withSort(expectedSort)
             .build();
     Assert.assertEquals(expectedQuery, actual.getQuery());
     Assert.assertEquals(expectedSearchFields, actual.getSearchFields());

--- a/client/src/test/java/com/tigrisdata/db/client/search/SortingOrderTest.java
+++ b/client/src/test/java/com/tigrisdata/db/client/search/SortingOrderTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2022 Tigris Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.tigrisdata.db.client.search;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tigrisdata.db.client.FieldSort;
+import com.tigrisdata.db.client.Sort;
+import com.tigrisdata.db.client.config.TigrisConfiguration;
+import java.util.Arrays;
+import java.util.Collection;
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class SortingOrderTest {
+  private static final ObjectMapper DEFAULT_OBJECT_MAPPER =
+      TigrisConfiguration.newBuilder("test").build().getObjectMapper();
+
+  @Parameter(0)
+  public String testCaseLabel;
+
+  @Parameter(1)
+  public SortingOrder orderInput;
+
+  @Parameter(2)
+  public String expectedJSON;
+
+  @Test
+  public void sortingOrderToJSON() {
+    Assert.assertEquals(expectedJSON, orderInput.toJSON(DEFAULT_OBJECT_MAPPER));
+  }
+
+  @Parameters(name = "{index}: {0}")
+  public static Collection<Object[]> SortingOrders() {
+    FieldSort field1_Asc = Sort.ascending("field_1");
+    FieldSort field1_Desc = Sort.descending("field_1");
+    FieldSort field2_Desc = Sort.descending("field_2");
+
+    return Arrays.asList(
+        new Object[][] {
+          {"Empty sort order", SortingOrder.newBuilder().build(), "[]"},
+          {
+            "Duplicate fields",
+            SortingOrder.newBuilder().withOrder(field1_Asc, field1_Desc).build(),
+            "[{\"field_1\":\"$desc\"}]"
+          },
+          {
+            "Single field",
+            SortingOrder.newBuilder().withOrder(field2_Desc).build(),
+            "[{\"field_2\":\"$desc\"}]"
+          },
+          {
+            "Multiple fields",
+            SortingOrder.newBuilder().withOrder(field2_Desc, field1_Asc).build(),
+            "[{\"field_2\":\"$desc\"},{\"field_1\":\"$asc\"}]"
+          }
+        });
+  }
+
+  @Test
+  public void equalsContract() {
+    EqualsVerifier.forClass(SortingOrder.class).withIgnoredFields("cachedJSON").verify();
+  }
+}


### PR DESCRIPTION
Interface to allow users to specify sort order for search results.

```java
TigrisSort asc = Sort.ascending("a");
TigrisSort desc = Sort.descending("b");

SearchRequest req = SearchRequest.matchAll().withSort(asc, desc).build();
```

OR

```java
TigrisSort asc = Sort.ascending("a");
TigrisSort desc = Sort.descending("b");
SortingOrder order = SortingOrder.withOrder(asc, desc).build()

SearchRequest req = SearchRequest.newBuilder().withQ("running").withSort(order).build();
```